### PR TITLE
fix: add DISABLE_CRONS on dev, and optimize reading history queries to reduce database bandwidth usage

### DIFF
--- a/convex/admin.ts
+++ b/convex/admin.ts
@@ -7,6 +7,12 @@ import { internalMutation } from "./_generated/server";
 export const cleanupOldReadings = internalMutation({
   args: {},
   handler: async (ctx) => {
+    // Skip in dev deployment to save database bandwidth
+    if (process.env.DISABLE_CRONS === "true") {
+      console.log("Cron skipped: DISABLE_CRONS is set");
+      return { totalDeleted: 0, skipped: true };
+    }
+
     const allSettings = await ctx.db.query("dataRetentionSettings").collect();
     const now = Date.now();
     let totalDeleted = 0;

--- a/convex/backup.ts
+++ b/convex/backup.ts
@@ -51,6 +51,11 @@ function backupEmailHtml(data: {
 export const checkAndRunBackups = internalAction({
   args: {},
   handler: async (ctx) => {
+    // Skip in dev deployment to save database bandwidth
+    if (process.env.DISABLE_CRONS === "true") {
+      return;
+    }
+
     const allSettings = await ctx.runQuery(
       internal.settings.getAllDataRetentionSettings
     );

--- a/convex/devices.ts
+++ b/convex/devices.ts
@@ -216,6 +216,11 @@ export const remove = mutation({
 export const checkDeviceAlerts = internalMutation({
   args: {},
   handler: async (ctx) => {
+    // Skip in dev deployment to save database bandwidth
+    if (process.env.DISABLE_CRONS === "true") {
+      return { alertsCreated: 0, skipped: true };
+    }
+
     const allDevices = await ctx.db.query("devices").collect();
     let alertsCreated = 0;
 

--- a/convex/ecoflow.ts
+++ b/convex/ecoflow.ts
@@ -252,6 +252,11 @@ function transformQuotaToReading(data: Record<string, number | string>) {
 export const collectAllUserReadings = internalAction({
   args: {},
   handler: async (ctx) => {
+    // Skip in dev deployment to save database bandwidth
+    if (process.env.DISABLE_CRONS === "true") {
+      return { success: true, skipped: true, reason: "DISABLE_CRONS is set" };
+    }
+
     const accessKey = process.env.ECOFLOW_ACCESS_KEY;
     const secretKey = process.env.ECOFLOW_SECRET_KEY;
 

--- a/src/hooks/useConvexData.ts
+++ b/src/hooks/useConvexData.ts
@@ -106,7 +106,7 @@ export function useConvexReadingHistory(
       ? {
           deviceId: deviceId as Id<"devices">,
           startTime: options?.startTime ?? Date.now() - 24 * 60 * 60 * 1000,
-          endTime: options?.endTime ?? Date.now() + 24 * 60 * 60 * 1000,
+          endTime: options?.endTime ?? Date.now(),
           aggregation: options?.aggregation,
         }
       : "skip"
@@ -180,9 +180,10 @@ function timeRangeToEpoch(timeRange: string): { startDate: number; endDate: numb
   };
   return {
     startDate: now - (rangeMs[timeRange] ?? rangeMs["24h"]),
-    // Use a generous future buffer so Convex reactive queries include
-    // new readings that arrive after the page loads (cron inserts every minute).
-    endDate: now + 24 * 60 * 60 * 1000,
+    // Cap to current time — the server-side query also caps to Date.now().
+    // This prevents reactive re-execution when new readings are inserted,
+    // which was the #1 source of DB bandwidth consumption.
+    endDate: now,
   };
 }
 


### PR DESCRIPTION
This pull request introduces several optimizations to reduce database bandwidth usage, particularly in development environments and for queries related to reading history. The main improvements include the ability to skip scheduled jobs with a new environment variable, adaptive query limits based on aggregation, and capping query time ranges to the current time to prevent unnecessary reactivity.

**Development/cron job optimization:**
- Added checks for the `DISABLE_CRONS` environment variable to skip running scheduled jobs (crons) in development or testing environments, reducing unnecessary database usage in `cleanupOldReadings`, `checkAndRunBackups`, `checkDeviceAlerts`, and `collectAllUserReadings` (`convex/admin.ts`, `convex/backup.ts`, `convex/devices.ts`, `convex/ecoflow.ts`). [[1]](diffhunk://#diff-c139679cee42e94b8bc300a602bddc55b29aa9b7270de7be3fc060574f65c93dR10-R15) [[2]](diffhunk://#diff-96fcf309a9859e907947f7990ec1c9fd4a3893c7bd56e5ab8446967ec571ad51R54-R58) [[3]](diffhunk://#diff-6ee2deafa63b34b35a39818a65e39b7619e7061173d5cc55b768a4ff2dca5582R219-R223) [[4]](diffhunk://#diff-1b04b6b3841cffff322c435b59cc7d7a63d328157326bc335fd872fb526e8784R255-R259)

**Reading history query optimizations:**
- Capped the `endTime` parameter to the current time (`Date.now()`) in both the server-side (`convex/readings.ts`) and client-side (`src/hooks/useConvexData.ts`) code to prevent queries from being re-executed reactively when new readings are inserted, which was previously the largest source of bandwidth consumption. [[1]](diffhunk://#diff-ac40db15a3f3c658abd85c6e5103e84305432042b7dfe747632dc0b77b2aad8cR113-R116) [[2]](diffhunk://#diff-12a6253890bca903e9d7e8a6248ced4121123221a08a2fa4424f5281ade94bedL109-R109) [[3]](diffhunk://#diff-12a6253890bca903e9d7e8a6248ced4121123221a08a2fa4424f5281ade94bedL183-R186)
- Introduced an adaptive row cap in the reading history query: when aggregation is enabled, the number of raw rows fetched is reduced, significantly saving bandwidth. [[1]](diffhunk://#diff-ac40db15a3f3c658abd85c6e5103e84305432042b7dfe747632dc0b77b2aad8cR133-R137) [[2]](diffhunk://#diff-ac40db15a3f3c658abd85c6e5103e84305432042b7dfe747632dc0b77b2aad8cL155-R176)
- Ensured that summary computations and queries use the effective (capped) end time for consistency and efficiency. [[1]](diffhunk://#diff-ac40db15a3f3c658abd85c6e5103e84305432042b7dfe747632dc0b77b2aad8cL155-R176) [[2]](diffhunk://#diff-ac40db15a3f3c658abd85c6e5103e84305432042b7dfe747632dc0b77b2aad8cL196-R207)