### PR TITLE
Feature/energy readings

### DIFF
--- a/src/app/(dashboard)/analytics/page.tsx
+++ b/src/app/(dashboard)/analytics/page.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState, useMemo } from "react";
 import { useConvexDevices, useConvexHistoryReadings } from "@/hooks/useConvexData";
 import { CombinedChart, BatteryLevelChart, TemperatureChart, transformReadingsToChartData } from "@/components/charts/HistoryCharts";
-import { Loader2, Battery, Thermometer, BarChart3, ExternalLink, Filter, ChevronDown, Search } from "lucide-react";
+import { Loader2, Battery, Thermometer, BarChart3, ExternalLink, Filter, ChevronDown, Search, Zap, Plug, Sun } from "lucide-react";
 import Link from "next/link";
 import { DateTimePicker } from '@/components/ui/DateTimePicker';
 
@@ -108,10 +108,80 @@ function AnalyticsPage() {
 		[readings]
 	);
 
+	// ─── Energy Totals (trapezoidal integration of watts → kWh) ──────────
+	const MS_PER_HOUR = 3_600_000;
+
+	const energyTotals = useMemo(() => {
+		if (readings.length < 2) return { consumed: 0, acInput: 0, solarInput: 0 };
+
+		// Max allowed gap between consecutive points (in hours) used for energy integration.
+		// Rationale:
+		// - "raw": up to 1h — primary cron is 1 min; allow short outages / retries without
+		//   stitching across long offline periods.
+		// - "5m": up to 0.5h — 5‑minute buckets should be relatively dense; we exclude wider
+		//   gaps to avoid over‑estimating when data is sparse.
+		// - "1h": up to 3h — hourly aggregation tolerates some jitter and the occasional
+		//   missing point while still capturing realistic daily totals.
+		// - "1d": up to 36h — daily aggregation can span a missed day (e.g. temporary outage)
+		//   without discarding nearby intervals, but we still cut off pathological gaps.
+		const maxGapHours: Record<string, number> = {
+			raw: 1,
+			'5m': 0.5,
+			'1h': 3,
+			'1d': 36,
+		};
+		// Default to 1h as a conservative fallback if a new/unknown aggregation key is used.
+		const maxGap = maxGapHours[filters.aggregation] ?? 1;
+
+		let consumedWh = 0;
+		let acInputWh = 0;
+		let solarInputWh = 0;
+
+		for (let i = 1; i < readings.length; i++) {
+			const prev = readings[i - 1] as any;
+			const curr = readings[i] as any;
+			const dtHours = (curr.recordedAt - prev.recordedAt) / MS_PER_HOUR;
+			if (dtHours <= 0 || dtHours > maxGap) continue;
+
+			// Only integrate intervals where both endpoints have a valid numeric value;
+			// null readings are excluded to avoid skewing totals with false zeros.
+			const hasOutput =
+				typeof prev.outputWatts === "number" &&
+				typeof curr.outputWatts === "number";
+			if (hasOutput) {
+				consumedWh += ((prev.outputWatts + curr.outputWatts) / 2) * dtHours;
+			}
+
+			const hasAcInput =
+				typeof prev.acInputWatts === "number" &&
+				typeof curr.acInputWatts === "number";
+			if (hasAcInput) {
+				acInputWh += ((prev.acInputWatts + curr.acInputWatts) / 2) * dtHours;
+			}
+
+			const hasSolarInput =
+				typeof prev.dcInputWatts === "number" &&
+				typeof curr.dcInputWatts === "number";
+			if (hasSolarInput) {
+				solarInputWh += ((prev.dcInputWatts + curr.dcInputWatts) / 2) * dtHours;
+			}
+		}
+
+		return {
+			consumed: consumedWh / 1000,
+			acInput: acInputWh / 1000,
+			solarInput: solarInputWh / 1000,
+		};
+	}, [readings, filters.aggregation]);
+
 	const formatValue = (value: number | null | undefined, unit: string) => {
 		if (value === null || value === undefined || isNaN(value)) return "0" + unit;
 		return value.toFixed(1) + unit;
 	};
+
+	/** Format energy value: 2 decimal places under 10 kWh, 1 above. */
+	const formatEnergy = (value: number) =>
+		value < 10 ? value.toFixed(2) : value.toFixed(1);
 
 	if (devicesLoading) {
 		return (
@@ -311,6 +381,47 @@ function AnalyticsPage() {
 									{formatValue(summary.avgTemperature, "°C")}
 								</div>
 								<div className="text-sm text-text-secondary">Avg Temperature</div>
+							</div>
+						</div>
+					)}
+
+					{/* Energy Totals Cards */}
+					{summary && (
+						<div className="grid grid-cols-1 sm:grid-cols-3 gap-[18px]">
+							{/* Energy Consumed */}
+							<div className="bg-surface-1 border border-stroke-subtle rounded-card shadow-card p-6 flex flex-col gap-2">
+								<div className="flex items-center gap-2 mb-1">
+									<Zap className="w-6 h-6 text-warning" />
+									<span className="text-sm text-text-secondary">Energy Consumed</span>
+								</div>
+								<div className="text-metric text-text-primary">
+									{formatEnergy(energyTotals.consumed)}
+								</div>
+								<span className="text-sm text-text-muted">kWh</span>
+							</div>
+
+							{/* AC Input */}
+							<div className="bg-surface-1 border border-stroke-subtle rounded-card shadow-card p-6 flex flex-col gap-2">
+								<div className="flex items-center gap-2 mb-1">
+									<Plug className="w-6 h-6 text-brand-tertiary" />
+									<span className="text-sm text-text-secondary">AC Input</span>
+								</div>
+								<div className="text-metric text-text-primary">
+									{formatEnergy(energyTotals.acInput)}
+								</div>
+								<span className="text-sm text-text-muted">kWh</span>
+							</div>
+
+							{/* Solar Input */}
+							<div className="bg-surface-1 border border-stroke-subtle rounded-card shadow-card p-6 flex flex-col gap-2">
+								<div className="flex items-center gap-2 mb-1">
+									<Sun className="w-6 h-6 text-brand-secondary" />
+									<span className="text-sm text-text-secondary">Solar Input</span>
+								</div>
+								<div className="text-metric text-text-primary">
+									{formatEnergy(energyTotals.solarInput)}
+								</div>
+								<span className="text-sm text-text-muted">kWh</span>
 							</div>
 						</div>
 					)}

--- a/src/app/(dashboard)/analytics/page.tsx
+++ b/src/app/(dashboard)/analytics/page.tsx
@@ -38,6 +38,8 @@ function formatTimeSpan(startTime: number, endTime: number): string {
 // 	endTime: number;
 // }
 
+const MS_PER_HOUR = 3_600_000;
+
 interface DeviceOption {
   id: string
   name: string
@@ -109,8 +111,6 @@ function AnalyticsPage() {
 	);
 
 	// ─── Energy Totals (trapezoidal integration of watts → kWh) ──────────
-	const MS_PER_HOUR = 3_600_000;
-
 	const energyTotals = useMemo(() => {
 		if (readings.length < 2) return { consumed: 0, acInput: 0, solarInput: 0 };
 

--- a/src/app/(dashboard)/analytics/page.tsx
+++ b/src/app/(dashboard)/analytics/page.tsx
@@ -26,17 +26,17 @@ function formatTimeSpan(startTime: number, endTime: number): string {
   return `${mins} minutes`;
 }
 
-interface HistorySummary {
-	totalReadings: number;
-	avgBatteryLevel: number;
-	avgPowerOutput: number;
-	avgTemperature: number;
-	peakPowerOutput: number;
-	lowestBatteryLevel: number;
-	highestTemperature: number;
-	startTime: number;
-	endTime: number;
-}
+// interface HistorySummary {
+// 	totalReadings: number;
+// 	avgBatteryLevel: number;
+// 	avgPowerOutput: number;
+// 	avgTemperature: number;
+// 	peakPowerOutput: number;
+// 	lowestBatteryLevel: number;
+// 	highestTemperature: number;
+// 	startTime: number;
+// 	endTime: number;
+// }
 
 interface DeviceOption {
   id: string
@@ -69,7 +69,7 @@ function AnalyticsPage() {
 		}))
 	];
 
-	const selectedDevice = deviceOptions.find(d => d.id === filters.deviceId);
+	// const selectedDevice = deviceOptions.find(d => d.id === filters.deviceId);
 
 	// Set default device when devices load
 	useEffect(() => {

--- a/src/app/(dashboard)/analytics/page.tsx
+++ b/src/app/(dashboard)/analytics/page.tsx
@@ -40,6 +40,26 @@ function formatTimeSpan(startTime: number, endTime: number): string {
 
 const MS_PER_HOUR = 3_600_000;
 
+/** Shape of a single reading returned by the Convex history query. */
+interface HistoryReading {
+  deviceId: string;
+  deviceName: string;
+  deviceSn: string;
+  batteryLevel: number | null;
+  inputWatts: number | null;
+  acInputWatts: number | null;
+  dcInputWatts: number | null;
+  chargingType: number | null;
+  outputWatts: number | null;
+  acOutputWatts: number | null;
+  dcOutputWatts: number | null;
+  usbOutputWatts: number | null;
+  remainingTime: number | null;
+  temperature: number | null;
+  status: string;
+  recordedAt: number;
+}
+
 interface DeviceOption {
   id: string
   name: string
@@ -103,7 +123,7 @@ function AnalyticsPage() {
 
 	// Convert readings to chart-compatible format (Date objects for recordedAt)
 	const chartReadings = useMemo(() =>
-		readings.map((r: any) => ({
+		(readings as HistoryReading[]).map((r) => ({
 			...r,
 			recordedAt: new Date(r.recordedAt),
 		})),
@@ -124,45 +144,35 @@ function AnalyticsPage() {
 		//   missing point while still capturing realistic daily totals.
 		// - "1d": up to 36h — daily aggregation can span a missed day (e.g. temporary outage)
 		//   without discarding nearby intervals, but we still cut off pathological gaps.
-		const maxGapHours: Record<string, number> = {
+		const maxGapHours: Record<HistoryFilters['aggregation'], number> = {
 			raw: 1,
 			'5m': 0.5,
 			'1h': 3,
 			'1d': 36,
 		};
-		// Default to 1h as a conservative fallback if a new/unknown aggregation key is used.
-		const maxGap = maxGapHours[filters.aggregation] ?? 1;
+		const maxGap = maxGapHours[filters.aggregation];
 
 		let consumedWh = 0;
 		let acInputWh = 0;
 		let solarInputWh = 0;
 
 		for (let i = 1; i < readings.length; i++) {
-			const prev = readings[i - 1] as any;
-			const curr = readings[i] as any;
+			const prev = readings[i - 1] as HistoryReading;
+			const curr = readings[i] as HistoryReading;
 			const dtHours = (curr.recordedAt - prev.recordedAt) / MS_PER_HOUR;
 			if (dtHours <= 0 || dtHours > maxGap) continue;
 
 			// Only integrate intervals where both endpoints have a valid numeric value;
 			// null readings are excluded to avoid skewing totals with false zeros.
-			const hasOutput =
-				typeof prev.outputWatts === "number" &&
-				typeof curr.outputWatts === "number";
-			if (hasOutput) {
+			if (prev.outputWatts != null && curr.outputWatts != null) {
 				consumedWh += ((prev.outputWatts + curr.outputWatts) / 2) * dtHours;
 			}
 
-			const hasAcInput =
-				typeof prev.acInputWatts === "number" &&
-				typeof curr.acInputWatts === "number";
-			if (hasAcInput) {
+			if (prev.acInputWatts != null && curr.acInputWatts != null) {
 				acInputWh += ((prev.acInputWatts + curr.acInputWatts) / 2) * dtHours;
 			}
 
-			const hasSolarInput =
-				typeof prev.dcInputWatts === "number" &&
-				typeof curr.dcInputWatts === "number";
-			if (hasSolarInput) {
+			if (prev.dcInputWatts != null && curr.dcInputWatts != null) {
 				solarInputWh += ((prev.dcInputWatts + curr.dcInputWatts) / 2) * dtHours;
 			}
 		}
@@ -258,7 +268,7 @@ function AnalyticsPage() {
 									<div className="relative">
 										<select
 											value={filters.timeRange}
-											onChange={(e) => setFilters(prev => ({ ...prev, timeRange: e.target.value as any }))}
+											onChange={(e) => setFilters(prev => ({ ...prev, timeRange: e.target.value as HistoryFilters['timeRange'] }))}
 											className="w-full bg-surface-2 border border-stroke-subtle rounded-inner px-3 py-2 text-text-primary focus:outline-none focus:border-brand-primary focus:ring-1 focus:ring-brand-primary/40 appearance-none pr-10"
 										>
 											<option value="1h">Last Hour</option>
@@ -280,7 +290,7 @@ function AnalyticsPage() {
 									<div className="relative">
 										<select
 											value={filters.aggregation}
-											onChange={(e) => setFilters(prev => ({ ...prev, aggregation: e.target.value as any }))}
+											onChange={(e) => setFilters(prev => ({ ...prev, aggregation: e.target.value as HistoryFilters['aggregation'] }))}
 											className="w-full bg-surface-2 border border-stroke-subtle rounded-inner px-3 py-2 text-text-primary focus:outline-none focus:border-brand-primary focus:ring-1 focus:ring-brand-primary/40 appearance-none pr-10"
 										>
 											<option value="raw">Raw Data</option>
@@ -412,11 +422,11 @@ function AnalyticsPage() {
 								<span className="text-sm text-text-muted">kWh</span>
 							</div>
 
-							{/* Solar Input */}
+							{/* DC Input (Solar/Car) */}
 							<div className="bg-surface-1 border border-stroke-subtle rounded-card shadow-card p-6 flex flex-col gap-2">
 								<div className="flex items-center gap-2 mb-1">
 									<Sun className="w-6 h-6 text-brand-secondary" />
-									<span className="text-sm text-text-secondary">Solar Input</span>
+									<span className="text-sm text-text-secondary">DC Input (Solar/Car)</span>
 								</div>
 								<div className="text-metric text-text-primary">
 									{formatEnergy(energyTotals.solarInput)}


### PR DESCRIPTION
This pull request introduces energy totals to the analytics dashboard, allowing users to view calculated energy consumption and input metrics. The main changes involve the calculation of energy consumed, AC input, and solar input using trapezoidal integration on device readings, and the display of these metrics in new summary cards. Additional utility functions and icons were added to support these features.

**Energy Calculation and Display:**

* Added a new `energyTotals` calculation using trapezoidal integration to estimate energy consumed, AC input, and solar input over time, with logic to handle gaps in readings based on aggregation type.
* Introduced three summary cards to the dashboard UI for displaying Energy Consumed, AC Input, and Solar Input, each with appropriate icons and styling.
* Added new icons (`Zap`, `Plug`, `Sun`) from `lucide-react` for visual representation of energy metrics.

**Codebase Maintenance:**

* Commented out the unused `HistorySummary` interface and related code to clean up the file.
* Removed the unused `selectedDevice` variable to streamline state management.