### PR TITLE
chore(engineering): standardize project practices

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,19 +1,17 @@
-# EcoFlow API Credentials
-# Get these from https://developer-eu.ecoflow.com/
-ECOFLOW_ACCESS_KEY=your_access_key_here
-ECOFLOW_SECRET_KEY=your_secret_key_here
+# Next.js / Convex client
+NEXT_PUBLIC_CONVEX_URL=https://your-deployment.convex.cloud
+CONVEX_DEPLOYMENT=dev:your-deployment
 
-# Supabase Configuration
-# Get these from your Supabase project dashboard
-NEXT_PUBLIC_SUPABASE_URL=your_supabase_project_url
-NEXT_PUBLIC_SUPABASE_ANON_KEY=your_supabase_anon_key
+# Optional URL used in email links
+NEXT_PUBLIC_APP_URL=http://localhost:3000
 
-# Database URL (from Supabase)
-DATABASE_URL=your_supabase_database_url
+# Legacy migration tooling only. Configure the same secret in Convex, run the
+# migration, then remove/rotate it. Do not use a real value in this file.
+MIGRATION_SECRET=replace-with-a-one-time-secret
 
-# NextAuth Configuration (if needed)
-NEXTAUTH_SECRET=your_nextauth_secret_here
-NEXTAUTH_URL=http://localhost:3000
-
-# Optional: Production URLs (for deployment)
-# NEXTAUTH_URL_PRODUCTION=https://your-domain.vercel.app
+# Set these in Convex Dashboard -> Settings -> Environment Variables:
+# CONVEX_SITE_URL=https://your-deployment.convex.site
+# ECOFLOW_ACCESS_KEY=replace-with-your-access-key
+# ECOFLOW_SECRET_KEY=replace-with-your-secret-key
+# RESEND_API_KEY=replace-with-your-resend-key
+# DISABLE_CRONS=true

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -26,7 +26,7 @@ All data fetching, mutations, and background jobs run on Convex. No Next.js API 
 
 | File | Purpose |
 |---|---|
-| `schema.ts` | 11 tables + authTables (users, devices, deviceReadings, deviceSettings, dailySummaries, alerts, dataRetentionSettings, notificationSettings, notificationLogs, sessionSettings, passwordChangeLog) |
+| `schema.ts` | 12 application tables + authTables (including device schedules) |
 | `auth.ts` / `auth.config.ts` | `@convex-dev/auth` with Password provider |
 | `http.ts` | HTTP router for auth endpoints |
 | `users.ts` | Profile queries/mutations |
@@ -38,7 +38,7 @@ All data fetching, mutations, and background jobs run on Convex. No Next.js API 
 | `email.ts` | Resend email sending (internal actions) |
 | `email_log.ts` | Email log queries |
 | `admin.ts` | Data cleanup mutation |
-| `crons.ts` | 4 scheduled jobs: collect-readings (1min), device-monitor (15min), data-cleanup (24h), backup-check (1h) |
+| `crons.ts` | 5 scheduled jobs: collect-readings (1min), device-monitor (15min), data-cleanup (24h), backup-check (1h), process-schedules (1min) |
 | `migrations.ts` | One-time Supabase→Convex data migration |
 
 ### Frontend (`src/`)
@@ -163,9 +163,11 @@ const isNetDischarging = hasPdRemainSign ? pdRemain < 0 : netPower < -10;
 ## Development
 
 ```bash
-# Application should already be running — do NOT start another dev server
+# Reuse an existing development server when one is already running
 npm run lint              # ESLint
 npm run type-check        # TypeScript
+npm run test              # Backend + frontend Vitest projects
+npm run verify            # Pre-push gate: lint, types, tests, build
 npm run build             # Production build
 
 # Convex
@@ -177,8 +179,8 @@ npx convex deploy         # Deploy to production
 
 ```bash
 # Convex (auto-configured)
-CONVEX_DEPLOYMENT=dev:acrobatic-swordfish-996
-NEXT_PUBLIC_CONVEX_URL=https://acrobatic-swordfish-996.convex.cloud
+CONVEX_DEPLOYMENT=dev:<your-deployment>
+NEXT_PUBLIC_CONVEX_URL=https://<your-deployment>.convex.cloud
 
 # EcoFlow API
 ECOFLOW_ACCESS_KEY=...
@@ -186,6 +188,9 @@ ECOFLOW_SECRET_KEY=...
 
 # Email (Resend)
 RESEND_API_KEY=...
+CONVEX_SITE_URL=https://<your-deployment>.convex.site
+DISABLE_CRONS=true # optional for development
+MIGRATION_SECRET=... # temporary, legacy migration only
 
 # Set in Convex Dashboard (not .env.local):
 # ECOFLOW_ACCESS_KEY, ECOFLOW_SECRET_KEY, RESEND_API_KEY

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,31 @@
+## Problem and outcome
+
+<!-- What problem does this solve, and what should users observe? -->
+
+## Change scope
+
+- [ ] Backend / Convex
+- [ ] Frontend / UI
+- [ ] Schema or data contract
+- [ ] EcoFlow device command
+- [ ] Documentation / engineering infrastructure
+
+## Safety and contracts
+
+- [ ] Public Convex functions authenticate and verify ownership
+- [ ] Arguments are validated and filtered reads use indexes
+- [ ] Schema changes are wired through persistence, queries, types, hooks, and UI
+- [ ] No secrets, personal data, or real device identifiers were added
+- [ ] Physical-device commands and email side effects were not exercised without authorization
+- [ ] `MEMORY.md` was updated for durable architecture or workflow changes
+
+## Verification
+
+- [ ] `npm run verify`
+- [ ] Regression tests were added or updated
+- [ ] `npm run test:e2e` (when applicable and an environment was available)
+- [ ] UI screenshots attached (when applicable)
+
+## Deployment and migration notes
+
+<!-- Environment variables, Convex deployment order, data migration, rollback, or "None". -->

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,1 @@
+npm run verify:commit

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,1 @@
+npm run verify:push

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,179 @@
+# AGENTS.md
+
+This file is the working contract for coding agents in this repository. It applies to the whole repository unless a more specific `AGENTS.md` is added below a directory.
+
+## Mission
+
+Maintain and extend the EcoFlow Delta 2 dashboard without weakening authentication, ownership checks, EcoFlow command correctness, Convex reactivity, or the existing dark design system.
+
+The application is a Next.js 15 App Router frontend backed directly by Convex. Convex owns authentication, persistence, server-side EcoFlow API calls, scheduled jobs, alerts, backups, and device schedules. There are no application Next.js API routes and no active Supabase runtime.
+
+## Instruction precedence and sources of truth
+
+1. Follow the user's request and system/developer instructions.
+2. Follow this file.
+3. Apply the scoped rules in `.github/instructions/` when they match the files being changed.
+4. Use `.github/copilot-instructions.md`, `.github/prompts/`, `README.md`, and `BACKGROUND_COLLECTION.md` as useful context, but verify their claims against current code.
+5. For EcoFlow protocol details, consult `.github/EcoFlow Developer.txt` and the working request/signing code in `convex/ecoflow.ts`.
+
+Current code and configuration win when documentation disagrees. Known stale facts are tracked in `MEMORY.md`.
+
+## Start every task this way
+
+- Read `AGENTS.md` and `MEMORY.md`.
+- Run `git status --short` and preserve all pre-existing work. Never discard, reset, overwrite, or reformat unrelated changes.
+- Inspect the relevant source, its callers, its Convex schema/validators, and nearby documentation before editing.
+- Check `.github/instructions/convex-patterns.instructions.md` for `convex/**/*.ts` work and `.github/instructions/testing-and-commits.instructions.md` for implementation work.
+- Use `rg`/`rg --files` for discovery. Do not search `.next`, `node_modules`, generated output, or secrets unless the task requires it.
+- Do not read or expose environment-variable values. It is safe to inspect variable names and `.env.example`.
+- Do not start another development server merely to inspect the project. Reuse an existing server if one is already running.
+
+## Repository map
+
+| Path | Responsibility |
+|---|---|
+| `src/app/` | Next.js App Router pages and layouts |
+| `src/app/(dashboard)/` | Authenticated dashboard routes |
+| `src/components/` | Shared layout, controls, charts, auth, and UI primitives |
+| `src/hooks/useConvexData.ts` | Main compatibility/bridge layer for reactive Convex data and actions |
+| `src/hooks/useOnDemandRefresh.ts` | Focus/navigation/manual refresh with a two-minute cooldown |
+| `src/lib/` | Formatting, chart theme, class utilities, and a legacy/server API wrapper |
+| `src/stores/uiStore.ts` | Zustand UI-only state; do not put server data here |
+| `src/types/` | Shared application types |
+| `convex/schema.ts` | Convex application tables and indexes |
+| `convex/*.ts` | Public and internal queries, mutations, actions, auth, and crons |
+| `convex/_generated/` | Convex-generated code; never edit by hand |
+| `scripts/` | One-time Supabase export/migration tooling, not application runtime |
+| `.github/instructions/` | Scoped implementation rules |
+| `.github/hooks/` | Copilot pre-commit lint/type-check hook definition |
+| `.github/prompts/` | Historical plans and reusable prompts |
+| `.github/EcoFlow Developer.txt` | Checked-in EcoFlow protocol reference |
+
+## Architecture invariants
+
+### Convex is the backend
+
+- Keep database access, external EcoFlow calls, scheduled collection, alerts, email, backups, and schedule execution in Convex.
+- Do not introduce a Next.js API route or a second persistence/auth layer without an explicit architectural decision.
+- Convex reactive queries are the primary server-state mechanism. Zustand is only for ephemeral UI concerns such as sidebar state and notifications.
+- Prefer the bridge hooks in `src/hooks/useConvexData.ts` for pages and components. Direct Convex hooks are acceptable for auth/provider code, the specialized refresh hook, or capabilities the bridge intentionally does not expose.
+- Auth gating in the browser is performed by `AuthWrapper`; `middleware.ts` is intentionally a no-op. Browser gating never replaces backend authorization.
+
+### Convex function rules
+
+- Every public query, mutation, and action must authenticate with `auth.getUserId(ctx)`.
+- `migrations.runMigration` is a legacy public action protected by a temporary `MIGRATION_SECRET`. Do not invoke it casually; remove or rotate the secret after migration work and never weaken this guard.
+- Unauthorized public queries return a shape-compatible empty value (`[]`, `null`, or an empty result object). Unauthorized mutations/actions throw `new Error("Unauthorized")`.
+- After authentication, verify resource ownership before reading, changing, deleting, refreshing, or controlling a device or schedule. Do not rely on possession of a Convex ID or serial number.
+- Internal functions are callable only by trusted backend code and do not require public auth guards.
+- Validate every argument with Convex validators. Use `v.id("table")` for document references, not `v.string()`.
+- Use schema indexes for filtered reads. Add the needed index in `convex/schema.ts` rather than replacing it with an unbounded filter/collect pattern.
+- Map documents to deliberate client-facing shapes. Do not leak `_id`, `_creationTime`, `userId`, raw API payloads, or credentials unless the caller genuinely needs them.
+- Convex optional fields often become `null` at the client boundary. Preserve the established `?? null` / `?? undefined` conventions deliberately.
+- Store timestamps as epoch milliseconds. Convert at UI/export boundaries.
+- Put `"use node";` at the top only in actions that require Node APIs or Node-only packages.
+- Keep one domain per module and use the existing section-comment organization.
+- Schema changes must be propagated through validators, insert/patch paths, query return shapes, frontend types/hooks, and UI consumers. Regenerate Convex types with `npx convex dev --once` when the change requires it and an appropriate deployment is configured.
+
+### Current data and job model
+
+`convex/schema.ts` currently defines 12 application tables in addition to `authTables`: `users`, `devices`, `deviceReadings`, `deviceSettings`, `dailySummaries`, `alerts`, `dataRetentionSettings`, `notificationSettings`, `notificationLogs`, `sessionSettings`, `passwordChangeLog`, and `deviceSchedules`.
+
+`convex/crons.ts` currently defines five jobs:
+
+- `collect-readings`: every minute; individual user collection intervals are enforced inside the action.
+- `device-monitor`: every 15 minutes.
+- `data-cleanup`: every 24 hours.
+- `backup-check`: every hour.
+- `process-schedules`: every minute.
+
+Cron implementations honor `DISABLE_CRONS=true`; preserve that guard for expensive or externally visible development work.
+
+### EcoFlow API correctness
+
+Treat device-control changes as high-risk integration work.
+
+- Use `https://api-e.ecoflow.com`, not `https://api.ecoflow.com`.
+- Keep credentials and HMAC-SHA256 signing server-side. Never move EcoFlow keys into `NEXT_PUBLIC_*` variables or client code.
+- Signature parameters are sorted. Nested SET payload parameters are flattened for signing.
+- The quota-all request includes `sn` in the URL but excludes it from the signature payload. Preserve this special case.
+- The authoritative runtime implementation is in `convex/ecoflow.ts`. `src/lib/ecoflow-api.ts` is a retained older wrapper and must not silently diverge into a second runtime path.
+- Consult `.github/EcoFlow Developer.txt` before adding or changing `moduleType`, `operateType`, units, ranges, or inverted boolean semantics.
+- Some SET operations require a complete parameter group even when the UI changes only one field. Read the current config and send all required sibling parameters for operations such as `acChgCfg`, `watthConfig`, `acAutoOutConfig`, and AC output configuration.
+- On a successful control action, follow the established sequence where applicable: send SET, optimistically patch the latest reading, then schedule a delayed authoritative refresh. Do not optimistically patch before the remote command succeeds.
+- `remainingTime` is signed: positive means time until full; negative means time remaining until empty. Charging/discharging uses the sign of `pd.remainTime` when available, with net input minus output and a ±10 W deadband as fallback. Simultaneous input and output is normal.
+- Be especially careful with buzzer/silent-mode fields: API names and UI meaning are inverted in places. Verify the protocol reference, transform, stored field, action, and label together.
+
+### Reading-query and bandwidth constraints
+
+- Keep `readings.history` bounded and indexed. It caps the effective end time, applies adaptive row limits, reads newest-first, then restores chronological order for charts.
+- Avoid fresh `Date.now()` values on every React render when they feed a reactive Convex query. Memoize or retain time windows as the existing hooks do.
+- On-demand refresh is client- and server-rate-limited around a two-minute staleness window. Preserve route-aware single-device refresh on `/device/[id]` pages.
+- Background collection is server-side. Do not add browser timers, service workers, Web Workers, wake locks, or polling loops to duplicate the Convex cron.
+
+## Frontend conventions
+
+- Next.js uses the App Router. Add `'use client'` only where browser APIs, state, effects, event handlers, or client hooks require it.
+- Components use PascalCase and explicit props interfaces. Hooks use the `use` prefix.
+- Use `@/` for imports rooted at `src/`. Existing Convex generated imports are relative because `convex/` is outside `src/`.
+- Preserve the route group and authenticated shell: root decides `/login` versus `/dashboard`; `(dashboard)/layout.tsx` wraps pages in `AuthWrapper` and `AppLayout`.
+- Use Formik/Yup where a page already uses them. Use Sonner for user-visible action feedback.
+- Prefer accessible roles, labels, keyboard behavior, focus states, and minimum touch targets. Test behavior rather than DOM implementation details.
+- Do not use `any` as a shortcut. Some legacy `any` remains; improve it locally when safe, but avoid broad unrelated refactors.
+
+### Design system
+
+- The product is dark-theme only and uses Neue Montreal from `public/fonts/`.
+- Tailwind CSS v4 tokens live in the `@theme` block in `src/app/globals.css`. There is no `tailwind.config.ts`.
+- Reuse semantic tokens (`bg-bg-base`, `bg-surface-1`, `text-text-primary`, `border-stroke-subtle`, `brand-primary`, etc.) instead of introducing arbitrary colors.
+- Reuse primitives from `src/components/ui/`: `Card`, `PillButton`, `Toggle`, `MetricDisplay`, `ChipSelector`, `KebabMenu`, and `DateTimePicker`.
+- Reuse `src/lib/chart-theme.ts` for Recharts styling and `cn()` from `src/lib/utils.ts` for class composition.
+- Preserve the matte card/pill visual language, 18 px cards, 12 px inner controls, responsive behavior, safe areas, and reduced mobile hover behavior.
+
+## Implementation workflow
+
+1. Establish the behavior and affected contracts before editing.
+2. For backend changes, update schema/functions/helpers and add focused tests.
+3. Run backend tests and type-check before changing dependent UI.
+4. Update bridge hooks/types and frontend UI, then add component tests.
+5. Run E2E tests for meaningful user-flow changes when the environment supports them.
+6. Review `git diff --check`, `git diff`, and `git status --short` before handing off.
+7. Update `MEMORY.md` whenever architecture, schema, jobs, environment requirements, invariants, known debt, or active work changes.
+
+Do not create commits, push, deploy Convex, change Vercel configuration, send email, or operate a real device unless the user explicitly asks. If commits are requested, keep backend and frontend commits separate where practical and use conventional messages such as `feat(backend): ...` or `fix(frontend): ...`. The hook in `.github/hooks/pre-commit-lint.json` requires lint and type-check before commit.
+
+## Verification matrix
+
+Run the smallest relevant checks during iteration, then broaden in proportion to risk.
+
+| Change | Required checks |
+|---|---|
+| Documentation only | Review rendered Markdown, `git diff --check` |
+| Convex/backend | `npm run test:backend`, `npm run type-check`, `npm run lint` |
+| React/UI | `npm run test:frontend`, `npm run type-check`, `npm run lint` |
+| Cross-stack | `npm run test`, `npm run type-check`, `npm run lint` |
+| Critical UI flow | Above plus `npm run test:e2e` if credentials/fixtures are available |
+| Release-sensitive | Above plus `npm run build` |
+
+The initial Vitest baseline covers EcoFlow protocol helpers, migration authorization, data formatting, and core UI controls. It is a starting point, not comprehensive coverage. Every bug fix should add a regression test, and new behavior should extend the relevant backend or frontend project.
+
+ESLint currently enforces the recorded warning ceiling so new warnings fail the pre-push gate. Reduce the ceiling as warnings are repaired; the target is zero. The verification gate always runs `npm run lint` explicitly before the build.
+
+Husky installs committed hooks through the `prepare` script. Pre-commit runs lint-staged; pre-push runs `npm run verify:push` (lint, types, tests, build). Do not bypass hooks with `--no-verify` except for a disclosed emergency.
+
+## Environment and operational safety
+
+Frontend/local configuration uses `NEXT_PUBLIC_CONVEX_URL` and `CONVEX_DEPLOYMENT`. Convex deployment variables include `CONVEX_SITE_URL`, `ECOFLOW_ACCESS_KEY`, `ECOFLOW_SECRET_KEY`, `RESEND_API_KEY`, optional `NEXT_PUBLIC_APP_URL`, optional `DISABLE_CRONS`, and temporary `MIGRATION_SECRET` for legacy imports.
+
+- `.env.example` contains safe placeholders only. Keep it synchronized with runtime variable names and never insert real values.
+- Never commit `.env*`, access keys, secret keys, deployment credentials, exported personal data, or real device serial numbers.
+- `scripts/supabase-export.json` may contain migrated user/device data. Treat it as sensitive even though it is checked in; do not print or edit it casually.
+- External actions can control physical power outputs, send email, or alter production data. Prefer static checks and mocks; require explicit authorization and a clearly identified environment for live operations.
+
+## Definition of done
+
+- The requested behavior is implemented without unrelated churn.
+- Auth, ownership, validation, indexes, protocol semantics, and client/server boundaries remain correct.
+- Relevant checks were run and their actual outcomes are reported; missing tests or environment blockers are stated plainly.
+- No secrets, generated-file edits, debug logging, or accidental user changes were introduced.
+- Documentation and `MEMORY.md` reflect any durable architectural change.

--- a/MEMORY.md
+++ b/MEMORY.md
@@ -1,0 +1,229 @@
+# MEMORY.md
+
+Living repository memory for future coding sessions. This is a factual snapshot, not a substitute for reading the source.
+
+**Last devoted update:** 2026-07-13  
+**Evidence reviewed:** current source/configuration, git history/status, `README.md`, `BACKGROUND_COLLECTION.md`, and all guidance under `.github/`.
+
+## Product snapshot
+
+My EcoFlow is a dark, responsive dashboard for monitoring and controlling EcoFlow Delta 2 power stations. It provides live battery/power/temperature status, historical analytics, device registration, control/configuration, scheduled commands, retention settings, alerts, email notifications, and JSON email backups.
+
+The deployed shape is:
+
+```text
+Browser / Next.js 15 App Router
+  -> Convex Auth + reactive queries/actions
+Convex Cloud
+  -> database and ownership checks
+  -> cron jobs and schedule engine
+  -> EcoFlow REST API (HMAC-SHA256)
+  -> Resend email
+```
+
+There are no application API routes. Supabase survives only in one-time migration scripts/data and stale documentation. Vercel serves the frontend; Convex Cloud runs the backend.
+
+## Current stack
+
+- Next.js `15.5.20`, React `19.1`, TypeScript 5, App Router, Turbopack
+- Convex `1.32` with `@convex-dev/auth` password authentication
+- Tailwind CSS v4 with tokens in `src/app/globals.css`
+- Zustand for UI-only state
+- Recharts for charts
+- Formik + Yup for forms
+- Sonner for toasts
+- Resend for email and backup delivery
+- Vitest + React Testing Library, Playwright, Husky, and lint-staged
+
+## Current source map
+
+### Routes
+
+- `/`: client-side auth-aware redirect
+- `/login`: sign-in/sign-up
+- `/dashboard`: overview and device cards
+- `/devices`: searchable/filterable device list
+- `/devices/add`: EcoFlow discovery and registration
+- `/device/[deviceId]`: device detail and quick controls
+- `/device/[deviceId]/settings`: full configuration and schedules
+- `/history`: readings table, charts, filters, and export
+- `/analytics`: energy and battery analytics
+- `/settings`: profile, notifications, retention/backup, session, and export UI
+
+All dashboard routes share `AuthWrapper` and `AppLayout`. `middleware.ts` is intentionally inactive (`matcher: []`).
+
+### Convex modules
+
+| Module | Current role |
+|---|---|
+| `schema.ts` | 12 application tables plus Convex auth tables |
+| `auth.ts`, `auth.config.ts`, `http.ts` | Password auth and auth HTTP routes |
+| `users.ts` | Profile read/update |
+| `devices.ts`, `devices_internal.ts` | Owned device CRUD, alert scan, internal device lookup |
+| `readings.ts` | Latest/history/count queries, aggregation/summary, insert and optimistic patch helpers |
+| `ecoflow.ts` | Signing, discovery, collection, refresh, and all device SET actions |
+| `settings.ts` | Retention, collection, backup, notification, and session settings |
+| `schedules.ts`, `schedules_internal.ts` | Owned CRUD and timezone-aware minute scheduler |
+| `admin.ts` | Retention cleanup |
+| `backup.ts`, `backup_queries.ts` | Seven-day JSON backup creation and Resend delivery |
+| `email.ts`, `email_log.ts` | Alert/test email delivery and logging |
+| `crons.ts` | Five scheduled jobs |
+| `migrations.ts` | One-time Supabase-to-Convex import |
+
+### Application tables
+
+`users`, `devices`, `deviceReadings`, `deviceSettings`, `dailySummaries`, `alerts`, `dataRetentionSettings`, `notificationSettings`, `notificationLogs`, `sessionSettings`, `passwordChangeLog`, and `deviceSchedules`.
+
+Important indexes include device ownership (`devices.by_userId`), latest/range readings (`deviceReadings.by_deviceId_recordedAt`), per-user settings, and device/user schedule lookups.
+
+### Scheduled work
+
+| Job | Cadence | Function |
+|---|---:|---|
+| `collect-readings` | 1 minute | `ecoflow.collectAllUserReadings` |
+| `device-monitor` | 15 minutes | `devices.checkDeviceAlerts` |
+| `data-cleanup` | 24 hours | `admin.cleanupOldReadings` |
+| `backup-check` | 1 hour | `backup.checkAndRunBackups` |
+| `process-schedules` | 1 minute | `schedules_internal.processSchedules` |
+
+The collection cron is only a tick: each user's `collectionIntervalMinutes` determines whether an actual EcoFlow request occurs. `DISABLE_CRONS=true` suppresses development-side collection, monitoring, cleanup, backup, and schedule processing.
+
+## Durable decisions and invariants
+
+### Data and auth
+
+- Convex is the sole live backend and authentication provider.
+- Normal public backend operations authenticate and enforce ownership. Client auth redirects are presentation only. The legacy public `migrations.runMigration` action additionally requires a deployment-side one-time `MIGRATION_SECRET`; remove or rotate it after migration use.
+- Reactive Convex data is server state. Zustand must remain UI-only.
+- Pages generally consume `src/hooks/useConvexData.ts`, which maps Convex documents into compatibility shapes expected by older UI code.
+- Convex IDs remain typed as `Id<"table">` at backend boundaries. Timestamps are epoch milliseconds in storage.
+
+### Collection and refresh
+
+- Background collection is server-side and browser-independent.
+- New readings are pushed through Convex reactivity; there is no normal client polling loop.
+- `useOnDemandRefresh` refreshes on focus, visibility, and navigation, with a two-minute client cooldown. The server independently skips fresh devices using the same approximate staleness threshold.
+- Device detail/settings routes refresh only that device; other routes may refresh all owned devices.
+- `readings.history` caps future end times to now, uses the compound index, limits rows adaptively, reads newest records first, reverses to chronological order, then aggregates.
+
+### EcoFlow integration
+
+- Base URL is `https://api-e.ecoflow.com`.
+- Requests use HMAC-SHA256 over alphabetically sorted parameters. Nested SET bodies are flattened before signing.
+- `/iot-open/sign/device/quota/all?sn=...` deliberately excludes `sn` from the signature payload.
+- `convex/ecoflow.ts` is the live implementation. `src/lib/ecoflow-api.ts` is retained legacy/server code and is not the frontend data path.
+- SET commands use numeric module types and protocol-specific operation names. Several operations reject partial payloads, so unchanged sibling values are loaded from the latest reading and resent.
+- Successful quick controls can patch the latest reading optimistically, then schedule a quota refresh after roughly five seconds.
+- Charging status is based on net power flow, with signed `pd.remainTime` preferred as the firmware signal. The fallback uses `inputWatts - outputWatts` with a ±10 W deadband.
+- Stored `remainingTime`: positive = until full, negative = until empty.
+- Buzzer terminology is dangerous: EcoFlow exposes silent/quiet mode while the UI presents buzzer enabled. Re-verify inversion end-to-end whenever touching it.
+
+### Schedules
+
+- At most five schedules are allowed per device.
+- Time is strict `HH:MM`; days use `0=Sunday` through `6=Saturday`; an empty array means every day.
+- Each schedule stores an IANA timezone and a generic EcoFlow action payload.
+- The minute cron computes local time with `Intl.DateTimeFormat`, checks day/time, prevents duplicate execution in the same local minute, and ignores inactive/missing devices.
+
+### UI and visual language
+
+- Dark theme only; Neue Montreal is loaded locally.
+- Tailwind v4 has no `tailwind.config.ts`; semantic tokens are declared in `globals.css`.
+- Core palette: base `#151615`, surface 1 `#1f201f`, surface 2 `#242624`, primary green `#44af21`, secondary green `#00c356`, tertiary blue `#3a6fe3`.
+- Cards use an 18 px radius, inner controls 12 px, and pills fully rounded.
+- Shared primitives live in `src/components/ui`; chart tokens live in `src/lib/chart-theme.ts`.
+- Mobile touch targets, safe-area handling, iOS input sizing, and global focus-visible styles are intentional.
+
+## Current working state on 2026-07-13
+
+The working tree already contained user-owned, uncommitted changes before `AGENTS.md` and this file were created:
+
+- `convex/schema.ts`: adds `deviceReadings.acChargingPaused`.
+- `convex/readings.ts`: reads the latest AC charging pause state for control payload construction.
+- `convex/ecoflow.ts`: extracts/preserves charging pause state while constructing AC charging commands and reuses current energy config for complete SET payloads.
+- `src/app/(dashboard)/device/[deviceId]/settings/page.tsx`: hardens the DC charging-current slider commit and removes an unused ref.
+
+Do not overwrite, revert, stage, or claim the original user changes without explicit user direction. During engineering standardization, `acChargingPaused` was completed across insertion, collection/refresh, optimistic patching, query return shapes, and frontend types. Re-run `git status --short` at the start of every session because this section will age.
+
+Recent committed work leading into this state added full device control/schedules, on-demand refresh, optimistic control state, correct required SET parameter groups, buzzer semantic fixes, and a DC input-current slider.
+
+## Known debt and sharp edges
+
+1. The initial 16-test baseline covers protocol helpers, migration authorization, formatting, and two UI primitives, but does not yet cover Convex database handlers, schedules, page flows, or E2E behavior.
+2. E2E infrastructure is configured but requires an appropriate running/authenticated environment and still has no committed E2E scenarios.
+3. README and Copilot architecture counts were synchronized to 12 application tables and five cron jobs; keep them updated with schema/job changes.
+4. The settings page contains a TODO for password changes with Convex Auth.
+5. `src/lib/ecoflow-api.ts` duplicates protocol logic from the Convex action module and includes development TLS bypass behavior. Avoid expanding this duplication.
+6. Several large page modules exceed 500 lines, and device settings exceeds 1,000 lines. Prefer targeted extraction when adding substantial behavior, but do not refactor them incidentally.
+7. Type shapes are duplicated between `src/types/index.ts`, `src/lib/data-utils.ts`, Convex return objects, and bridge hooks. Schema field additions can easily be missed in one layer.
+8. Some legacy `any` usages remain, notably UI compatibility code. Avoid introducing more.
+9. `.github/hooks/pre-commit-lint.json` is a Copilot hook definition, not proof that every local Git client runs those checks; Husky is the repository-wide local gate.
+10. `scripts/supabase-export.json` is checked in and may contain sensitive migrated data/device identifiers. Do not print or modify it casually.
+11. Comments/field names around `buzzerSilent` have historically drifted from UI semantics. Trust verified behavior and protocol docs, not a single label.
+12. `migrations.runMigration` remains public for the legacy script, although it is now guarded by `MIGRATION_SECRET`. Prefer internalizing or deleting the migration surface once it is no longer needed.
+13. `npm audit` reports two moderate PostCSS advisories nested under Next.js. The remaining automatic remedy proposes a breaking/invalid Next downgrade, so it was not forced; reassess during the next framework upgrade.
+
+Current quality baseline at this update: `npm run type-check` passes; all 16 tests pass; `npm run lint` has a ceiling of 48 existing warnings and zero errors. The warnings are chiefly legacy `any`, unused imports/variables, the anonymous auth-config export, and two generated JavaScript eslint directives. Reduce the ceiling whenever warnings are repaired; the target is zero.
+
+Committed Husky hooks are installed through `npm install`/`prepare`: pre-commit runs lint-staged and pre-push runs lint, type-check, all Vitest projects, and a production build. Git's `--no-verify` escape hatch must be exceptional and disclosed.
+
+## Environment contract
+
+Do not record values here. Active variable names inferred from the runtime are:
+
+### Local/Next.js
+
+- `NEXT_PUBLIC_CONVEX_URL`
+- `CONVEX_DEPLOYMENT` (Convex CLI/deployment selection)
+- `CI` for Playwright behavior
+
+### Convex deployment
+
+- `CONVEX_SITE_URL` for auth provider configuration
+- `ECOFLOW_ACCESS_KEY`
+- `ECOFLOW_SECRET_KEY`
+- `RESEND_API_KEY`
+- `NEXT_PUBLIC_APP_URL` (optional; email links have a production fallback)
+- `DISABLE_CRONS` (optional; use `"true"` in development when appropriate)
+- `MIGRATION_SECRET` (temporary; legacy migration authorization only)
+
+The migration exporter additionally reads `DATABASE_URL`, but that belongs to one-time legacy migration tooling.
+
+## Commands and verification reality
+
+```bash
+npm run dev            # Next dev server with Turbopack
+npm run build          # Production build
+npm run lint           # ESLint
+npm run type-check     # tsc --noEmit
+npm run test           # all Vitest projects
+npm run test:backend   # convex/__tests__/**/*.test.ts
+npm run test:frontend  # src/**/*.test.{ts,tsx}
+npm run test:e2e       # Playwright, expects localhost:3000
+npm run verify         # pre-push gate: lint, types, tests, build
+npm run verify:full    # verify plus Playwright E2E
+npx convex dev         # deploy/watch development Convex functions
+npx convex deploy      # production Convex deployment; explicit authorization required
+```
+
+Node 18+ is documented as the minimum. `package-lock.json` is authoritative for npm installs.
+
+## How to update this memory devotedly
+
+Update this file in the same change whenever any of the following changes:
+
+- product scope, framework/backend/auth provider, deployment shape, or data flow;
+- route, Convex module, table, index, cron, or environment-variable contract;
+- EcoFlow signing, quota transformation, command semantics, refresh/optimistic-update flow, or physical-device safety rule;
+- testing commands, actual test coverage, build/lint behavior, or commit gates;
+- a known debt item is fixed, replaced, or newly discovered;
+- significant active work is left uncommitted for the next agent.
+
+Maintenance procedure:
+
+1. Re-read the changed source and relevant `.github` instruction/reference files.
+2. Verify facts with `rg`, `package.json`, `convex/schema.ts`, `convex/crons.ts`, and `git status --short` rather than copying older prose.
+3. Change the **Last devoted update** date.
+4. Move resolved debt out instead of accumulating historical clutter.
+5. Keep secrets, personal data, deployment IDs, and real serial numbers out of this file.
+6. Keep this as a concise current-state handoff; use Git history for archaeology.

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Browser (React)
   ↕ Convex reactive queries (WebSocket)
 Convex Cloud
   ├── Auth (email/password)
-  ├── Database (11 tables)
+  ├── Database (12 application tables + Convex auth tables)
   ├── Cron Jobs (collect readings, monitor, cleanup)
   └── Actions → EcoFlow REST API (HMAC-SHA256)
 ```
@@ -81,6 +81,8 @@ Convex Cloud
 | `collect-readings` | 1 min | Poll EcoFlow API, store readings |
 | `device-monitor` | 15 min | Check thresholds, send alerts |
 | `data-cleanup` | 24 hours | Delete readings past retention period |
+| `backup-check` | 1 hour | Send scheduled JSON backups by email |
+| `process-schedules` | 1 min | Execute timezone-aware device schedules |
 
 ## Scripts
 
@@ -89,9 +91,26 @@ npm run dev          # Development server (Turbopack)
 npm run build        # Production build
 npm run lint         # ESLint
 npm run type-check   # TypeScript validation
+npm run test         # Backend and frontend tests
+npm run verify       # Full pre-push quality gate
 npx convex dev       # Convex dev mode (watch + deploy)
 npx convex deploy    # Deploy Convex to production
 ```
+
+## Engineering workflow
+
+Run `npm install` once to install dependencies and activate the committed Husky
+hooks. The hooks enforce the same repository scripts on every contributor's
+machine:
+
+- Pre-commit runs ESLint against staged source files.
+- Pre-push runs lint, type-checking, all Vitest projects, and a production build.
+- `npm run verify:full` adds Playwright E2E tests when the required local
+  environment and credentials are available.
+
+Hooks can be bypassed with Git's `--no-verify` escape hatch, but doing so should
+be exceptional and disclosed in the pull request. See `AGENTS.md` for the full
+engineering contract and `MEMORY.md` for the current architecture snapshot.
 
 ## Project Structure
 

--- a/convex/__tests__/ecoflow.test.ts
+++ b/convex/__tests__/ecoflow.test.ts
@@ -1,0 +1,89 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  flattenParams,
+  generateSignature,
+  transformQuotaToReading,
+} from "../ecoflow";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("EcoFlow protocol helpers", () => {
+  it("generates a stable signature with alphabetically sorted parameters", () => {
+    const signature = generateSignature(
+      "secret",
+      "access",
+      { z: 9, a: 1 },
+      1_700_000_000_000,
+      "123456"
+    );
+
+    expect(signature).toBe(
+      "d8eb1e79e37aa000cb453ae6ec66be2da447375e302d551504d99cdc4e5ebade"
+    );
+  });
+
+  it("flattens nested SET payloads using dot-separated keys", () => {
+    expect(
+      flattenParams({
+        sn: "R351",
+        moduleType: 5,
+        params: { enabled: 1, nested: { watts: 600 } },
+      })
+    ).toEqual({
+      sn: "R351",
+      moduleType: "5",
+      "params.enabled": "1",
+      "params.nested.watts": "600",
+    });
+  });
+
+  it("uses the firmware sign and precise charge time when net charging", () => {
+    vi.spyOn(Date, "now").mockReturnValue(1_700_000_000_000);
+
+    const reading = transformQuotaToReading({
+      "pd.wattsInSum": 500,
+      "pd.wattsOutSum": 100,
+      "pd.remainTime": 120,
+      "bms_emsStatus.chgRemainTime": 115,
+      "bms_emsStatus.dsgRemainTime": 300,
+      "bms_bmsStatus.soc": 75,
+      "mppt.chgPauseFlag": 1,
+    });
+
+    expect(reading).toMatchObject({
+      status: "charging",
+      inputWatts: 500,
+      outputWatts: 100,
+      remainingTime: 115,
+      batteryLevel: 75,
+      acChargingPaused: true,
+      recordedAt: 1_700_000_000_000,
+    });
+  });
+
+  it("stores discharge time as negative even with simultaneous input", () => {
+    const reading = transformQuotaToReading({
+      "pd.wattsInSum": 100,
+      "pd.wattsOutSum": 400,
+      "pd.remainTime": -90,
+      "bms_emsStatus.chgRemainTime": 200,
+      "bms_emsStatus.dsgRemainTime": 88,
+    });
+
+    expect(reading.status).toBe("discharging");
+    expect(reading.remainingTime).toBe(-88);
+  });
+
+  it("uses the net-power deadband when firmware remaining time has no sign", () => {
+    expect(
+      transformQuotaToReading({
+        "pd.wattsInSum": 105,
+        "pd.wattsOutSum": 100,
+        "pd.remainTime": 0,
+        "bms_bmsStatus.soc": 50,
+      }).status
+    ).toBe("standby");
+  });
+});

--- a/convex/__tests__/migrations.test.ts
+++ b/convex/__tests__/migrations.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { assertMigrationAuthorized } from "../migrations";
+
+describe("migration authorization", () => {
+  it("rejects migration when the deployment has no configured secret", () => {
+    expect(() => assertMigrationAuthorized(undefined, "provided")).toThrow(
+      "Migration is not authorized"
+    );
+  });
+
+  it("rejects migration when the provided secret does not match", () => {
+    expect(() => assertMigrationAuthorized("configured", "wrong")).toThrow(
+      "Migration is not authorized"
+    );
+  });
+
+  it("allows migration when the one-time secret matches", () => {
+    expect(() =>
+      assertMigrationAuthorized("configured", "configured")
+    ).not.toThrow();
+  });
+});

--- a/convex/ecoflow.ts
+++ b/convex/ecoflow.ts
@@ -26,7 +26,7 @@ interface APIResponse<T = Record<string, unknown>> {
 
 // ─── EcoFlow API Helpers (ported from src/lib/ecoflow-api.ts) ────────────────
 
-function generateSignature(
+export function generateSignature(
   secretKey: string,
   accessKey: string,
   params: Record<string, string | number>,
@@ -118,7 +118,7 @@ async function getDeviceList(
  * Flatten a nested object into dot-separated key-value pairs for signature generation.
  * E.g. { sn: "X", params: { enabled: 1 } } → { "sn": "X", "params.enabled": "1" }
  */
-function flattenParams(
+export function flattenParams(
   obj: Record<string, unknown>,
   prefix = ""
 ): Record<string, string> {
@@ -236,7 +236,7 @@ function getQuotaValue(
   return isNaN(num) ? null : num;
 }
 
-function transformQuotaToReading(data: Record<string, number | string>) {
+export function transformQuotaToReading(data: Record<string, number | string>) {
   // === INPUT POWER ===
   const acInputWatts = getQuotaValue(data, "inv.inputWatts") || 0;
   const dcInputWatts = getQuotaValue(data, "mppt.inWatts") || 0;
@@ -327,6 +327,7 @@ function transformQuotaToReading(data: Record<string, number | string>) {
     acOutVoltage: getQuotaValue(data, "mppt.cfgAcOutVol") ?? undefined,
     acOutFrequency: getQuotaValue(data, "mppt.cfgAcOutFreq") ?? undefined,
     acChargingWatts: getQuotaValue(data, "mppt.cfgChgWatts") ?? undefined,
+    acChargingPaused: getQuotaValue(data, "mppt.chgPauseFlag") === 1 ? true : getQuotaValue(data, "mppt.chgPauseFlag") === 0 ? false : undefined,
     dcChargingCurrent: getQuotaValue(data, "mppt.dcChgCurrent") ?? undefined,
     acStandbyMins: getQuotaValue(data, "mppt.acStandbyMins") ?? undefined,
     carStandbyMins: getQuotaValue(data, "mppt.carStandbyMin") ?? undefined,
@@ -433,6 +434,7 @@ export const collectAllUserReadings = internalAction({
                 acOutVoltage: reading.acOutVoltage,
                 acOutFrequency: reading.acOutFrequency,
                 acChargingWatts: reading.acChargingWatts,
+                acChargingPaused: reading.acChargingPaused,
                 dcChargingCurrent: reading.dcChargingCurrent,
                 acStandbyMins: reading.acStandbyMins,
                 carStandbyMins: reading.carStandbyMins,
@@ -711,7 +713,7 @@ export const setChargingConfig = action({
       const currentConfig = await ctx.runQuery(internal.readings.getLatestAcConfig, { deviceId: device._id });
       const params = {
         chgWatts: args.chgWatts ?? currentConfig?.acChargingWatts ?? 600,
-        chgPauseFlag: args.chgPauseFlag !== undefined ? (args.chgPauseFlag ? 1 : 0) : 0,
+        chgPauseFlag: args.chgPauseFlag !== undefined ? (args.chgPauseFlag ? 1 : 0) : (currentConfig?.acChargingPaused ? 1 : 0),
       };
 
       const result = await setDeviceQuotaRequest(accessKey, secretKey, {
@@ -729,8 +731,9 @@ export const setChargingConfig = action({
     }
 
     // Optimistic UI patch
-    const patchFields: Record<string, number> = {};
+    const patchFields: Record<string, number | boolean> = {};
     if (args.chgWatts !== undefined) patchFields.acChargingWatts = args.chgWatts;
+    if (args.chgPauseFlag !== undefined) patchFields.acChargingPaused = args.chgPauseFlag;
     if (args.dcChgCurrent !== undefined) patchFields.dcChargingCurrent = args.dcChgCurrent;
     if (Object.keys(patchFields).length > 0) {
       await ctx.runMutation(internal.readings.patchLatestReading, {
@@ -834,9 +837,15 @@ export const setEnergyManagement = action({
 
     const { device, accessKey, secretKey } = await validateDeviceAccess(ctx, userId, args.deviceSn);
 
+    // Fetch energy config once for both watthConfig and acAutoOutConfig blocks
+    const needsEnergyConfig = args.isConfig !== undefined || args.bpPowerSoc !== undefined ||
+      args.acAutoOutConfig !== undefined || args.minAcOutSoc !== undefined;
+    const currentConfig = needsEnergyConfig
+      ? await ctx.runQuery(internal.readings.getLatestEnergyConfig, { deviceId: device._id })
+      : null;
+
     // Energy management config — watthConfig requires all 4 params
     if (args.isConfig !== undefined || args.bpPowerSoc !== undefined) {
-      const currentConfig = await ctx.runQuery(internal.readings.getLatestEnergyConfig, { deviceId: device._id });
       const params = {
         isConfig: args.isConfig !== undefined ? (args.isConfig ? 1 : 0) : (currentConfig?.energyMgmtEnabled ? 1 : 0),
         bpPowerSoc: args.bpPowerSoc ?? currentConfig?.backupReserveSoc ?? 50,
@@ -861,7 +870,6 @@ export const setEnergyManagement = action({
 
     // AC always on — acAutoOutConfig requires both params
     if (args.acAutoOutConfig !== undefined || args.minAcOutSoc !== undefined) {
-      const currentConfig = await ctx.runQuery(internal.readings.getLatestEnergyConfig, { deviceId: device._id });
       const params = {
         acAutoOutConfig: args.acAutoOutConfig !== undefined ? (args.acAutoOutConfig ? 1 : 0) : (currentConfig?.acAutoOutEnabled ? 1 : 0),
         minAcOutSoc: args.minAcOutSoc ?? currentConfig?.minAcOutSoc ?? 20,
@@ -1065,6 +1073,7 @@ export const refreshDeviceReading = internalAction({
         acOutVoltage: reading.acOutVoltage,
         acOutFrequency: reading.acOutFrequency,
         acChargingWatts: reading.acChargingWatts,
+        acChargingPaused: reading.acChargingPaused,
         dcChargingCurrent: reading.dcChargingCurrent,
         acStandbyMins: reading.acStandbyMins,
         carStandbyMins: reading.carStandbyMins,
@@ -1185,6 +1194,7 @@ export const refreshReadings = action({
             acOutVoltage: reading.acOutVoltage,
             acOutFrequency: reading.acOutFrequency,
             acChargingWatts: reading.acChargingWatts,
+            acChargingPaused: reading.acChargingPaused,
             dcChargingCurrent: reading.dcChargingCurrent,
             acStandbyMins: reading.acStandbyMins,
             carStandbyMins: reading.carStandbyMins,

--- a/convex/migrations.ts
+++ b/convex/migrations.ts
@@ -338,6 +338,15 @@ export const createDefaultSettings = internalMutation({
 
 // ─── Orchestrating action ────────────────────────────────────────────────────
 
+export function assertMigrationAuthorized(
+  configuredSecret: string | undefined,
+  providedSecret: string
+) {
+  if (!configuredSecret || providedSecret !== configuredSecret) {
+    throw new Error("Migration is not authorized");
+  }
+}
+
 /**
  * Main migration action. Call from the Convex dashboard or CLI.
  *
@@ -351,6 +360,7 @@ export const createDefaultSettings = internalMutation({
  */
 export const runMigration = action({
   args: {
+    migrationSecret: v.string(),
     userId: v.id("users"),
     data: v.object({
       devices: v.array(supabaseDeviceValidator),
@@ -361,6 +371,8 @@ export const runMigration = action({
     }),
   },
   handler: async (ctx, args) => {
+    assertMigrationAuthorized(process.env.MIGRATION_SECRET, args.migrationSecret);
+
     const results: Record<string, unknown> = {};
 
     // Step 1: Import devices and get ID mapping

--- a/convex/readings.ts
+++ b/convex/readings.ts
@@ -1,4 +1,4 @@
-import { query, mutation, internalMutation, internalQuery } from "./_generated/server";
+import { query, internalMutation, internalQuery } from "./_generated/server";
 import { v } from "convex/values";
 import { auth } from "./auth";
 import { Id } from "./_generated/dataModel";
@@ -56,6 +56,7 @@ export const latest = query({
               acOutVoltage: reading.acOutVoltage ?? null,
               acOutFrequency: reading.acOutFrequency ?? null,
               acChargingWatts: reading.acChargingWatts ?? null,
+              acChargingPaused: reading.acChargingPaused ?? null,
               dcChargingCurrent: reading.dcChargingCurrent ?? null,
               acStandbyMins: reading.acStandbyMins ?? null,
               carStandbyMins: reading.carStandbyMins ?? null,
@@ -121,6 +122,7 @@ export const latestForDevice = query({
           acOutVoltage: reading.acOutVoltage ?? null,
           acOutFrequency: reading.acOutFrequency ?? null,
           acChargingWatts: reading.acChargingWatts ?? null,
+          acChargingPaused: reading.acChargingPaused ?? null,
           dcChargingCurrent: reading.dcChargingCurrent ?? null,
           acStandbyMins: reading.acStandbyMins ?? null,
           carStandbyMins: reading.carStandbyMins ?? null,
@@ -326,6 +328,7 @@ export const getLatestAcConfig = internalQuery({
       acOutVoltage: latest.acOutVoltage ?? undefined,
       acOutFrequency: latest.acOutFrequency ?? undefined,
       acChargingWatts: latest.acChargingWatts ?? undefined,
+      acChargingPaused: latest.acChargingPaused ?? false,
     };
   },
 });
@@ -369,6 +372,7 @@ export const patchLatestReading = internalMutation({
       acXboost: v.optional(v.boolean()),
       buzzerSilent: v.optional(v.boolean()),
       acChargingWatts: v.optional(v.float64()),
+      acChargingPaused: v.optional(v.boolean()),
       dcChargingCurrent: v.optional(v.float64()),
       maxChargeSoc: v.optional(v.float64()),
     }),
@@ -388,6 +392,7 @@ export const patchLatestReading = internalMutation({
     if (args.fields.acXboost !== undefined) patch.acXboost = args.fields.acXboost;
     if (args.fields.buzzerSilent !== undefined) patch.buzzerSilent = args.fields.buzzerSilent;
     if (args.fields.acChargingWatts !== undefined) patch.acChargingWatts = args.fields.acChargingWatts;
+    if (args.fields.acChargingPaused !== undefined) patch.acChargingPaused = args.fields.acChargingPaused;
     if (args.fields.dcChargingCurrent !== undefined) patch.dcChargingCurrent = args.fields.dcChargingCurrent;
     if (args.fields.maxChargeSoc !== undefined) patch.maxChargeSoc = args.fields.maxChargeSoc;
 
@@ -423,6 +428,7 @@ export const insertReading = internalMutation({
     acOutVoltage: v.optional(v.float64()),
     acOutFrequency: v.optional(v.float64()),
     acChargingWatts: v.optional(v.float64()),
+    acChargingPaused: v.optional(v.boolean()),
     dcChargingCurrent: v.optional(v.float64()),
     acStandbyMins: v.optional(v.float64()),
     carStandbyMins: v.optional(v.float64()),
@@ -464,6 +470,7 @@ export const insertReading = internalMutation({
       acOutVoltage: args.acOutVoltage,
       acOutFrequency: args.acOutFrequency,
       acChargingWatts: args.acChargingWatts,
+      acChargingPaused: args.acChargingPaused,
       dcChargingCurrent: args.dcChargingCurrent,
       acStandbyMins: args.acStandbyMins,
       carStandbyMins: args.carStandbyMins,

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -56,6 +56,7 @@ export default defineSchema({
     acOutVoltage: v.optional(v.float64()),
     acOutFrequency: v.optional(v.float64()),
     acChargingWatts: v.optional(v.float64()),
+    acChargingPaused: v.optional(v.boolean()),
     dcChargingCurrent: v.optional(v.float64()),
     acStandbyMins: v.optional(v.float64()),
     carStandbyMins: v.optional(v.float64()),

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,11 +1,5 @@
 import type { NextConfig } from "next";
 
-const nextConfig: NextConfig = {
-  eslint: {
-    // Warning: This disables ESLint during builds
-    // Only use this as a temporary fix while resolving warnings
-    ignoreDuringBuilds: true,
-  },
-};
+const nextConfig: NextConfig = {};
 
 export default nextConfig;

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "framer-motion": "^12.23.16",
         "gsap": "^3.13.0",
         "lucide-react": "^0.544.0",
-        "next": "15.5.12",
+        "next": "^15.5.20",
         "react": "19.1.0",
         "react-dom": "19.1.0",
         "recharts": "^3.2.1",
@@ -43,8 +43,10 @@
         "@types/react-dom": "^19",
         "@vitejs/plugin-react": "^6.0.1",
         "eslint": "^9",
-        "eslint-config-next": "15.5.3",
+        "eslint-config-next": "^15.5.20",
+        "husky": "^9.1.7",
         "jsdom": "^29.0.2",
+        "lint-staged": "^17.0.8",
         "tailwindcss": "^4",
         "typescript": "^5",
         "vitest": "^4.1.4"
@@ -383,21 +385,21 @@
       }
     },
     "node_modules/@emnapi/core": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
-      "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
+        "@emnapi/wasi-threads": "1.2.2",
         "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
-      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -405,9 +407,9 @@
       }
     },
     "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
-      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -1547,15 +1549,15 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "15.5.12",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.5.12.tgz",
-      "integrity": "sha512-pUvdJN1on574wQHjaBfNGDt9Mz5utDSZFsIIQkMzPgNS8ZvT4H2mwOrOIClwsQOb6EGx5M76/CZr6G8i6pSpLg==",
+      "version": "15.5.20",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.5.20.tgz",
+      "integrity": "sha512-dXh51Wvddf8daEyBXryZZEe1FdVxEWx9lgaTseLZUtC1XP/W8Wri+Z+VPOElHlByk23CyqHdc2oVByX7wsTWsw==",
       "license": "MIT"
     },
     "node_modules/@next/eslint-plugin-next": {
-      "version": "15.5.3",
-      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-15.5.3.tgz",
-      "integrity": "sha512-SdhaKdko6dpsSr0DldkESItVrnPYB1NS2NpShCSX5lc7SSQmLZt5Mug6t2xbiuVWEVDLZSuIAoQyYVBYp0dR5g==",
+      "version": "15.5.20",
+      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-15.5.20.tgz",
+      "integrity": "sha512-MZUgFpVd9rGSZpb8bNceUWvkAZe6aQw/6h2SSqHQuYzKfaiEUEVPIO6mXqaBmiBEBSN1f1sOc1uV8GCM90oegg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1563,9 +1565,9 @@
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "15.5.12",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.5.12.tgz",
-      "integrity": "sha512-RnRjBtH8S8eXCpUNkQ+543DUc7ys8y15VxmFU9HRqlo9BG3CcBUiwNtF8SNoi2xvGCVJq1vl2yYq+3oISBS0Zg==",
+      "version": "15.5.20",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.5.20.tgz",
+      "integrity": "sha512-in0yXG7/pRBVjWeEl7f7ZZETpletSMFKXVS4GJgHENTPVrJFNJKPrYewa9rpZcvdjwFece5fZP0CK34G4PxowA==",
       "cpu": [
         "arm64"
       ],
@@ -1579,9 +1581,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "15.5.12",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.5.12.tgz",
-      "integrity": "sha512-nqa9/7iQlboF1EFtNhWxQA0rQstmYRSBGxSM6g3GxvxHxcoeqVXfGNr9stJOme674m2V7r4E3+jEhhGvSQhJRA==",
+      "version": "15.5.20",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.5.20.tgz",
+      "integrity": "sha512-0hsFshdPnTzGJdDTHeHJ+XPUShOpnyp9pUFDwDhqctsA0Cd8NcIVGRPtptYhgYY9DjkKgCDRkXxmgRc+CgT5Wg==",
       "cpu": [
         "x64"
       ],
@@ -1595,9 +1597,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "15.5.12",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.5.12.tgz",
-      "integrity": "sha512-dCzAjqhDHwmoB2M4eYfVKqXs99QdQxNQVpftvP1eGVppamXh/OkDAwV737Zr0KPXEqRUMN4uCjh6mjO+XtF3Mw==",
+      "version": "15.5.20",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.5.20.tgz",
+      "integrity": "sha512-DMvkoBtAABOzE6pMZRW/xNm7sKqql3wzzzZJ1R/d/rp4BCxv6LykouD3tHjGY8WdQqGpZs11t+R9AtjPxvvljw==",
       "cpu": [
         "arm64"
       ],
@@ -1611,9 +1613,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "15.5.12",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.5.12.tgz",
-      "integrity": "sha512-+fpGWvQiITgf7PUtbWY1H7qUSnBZsPPLyyq03QuAKpVoTy/QUx1JptEDTQMVvQhvizCEuNLEeghrQUyXQOekuw==",
+      "version": "15.5.20",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.5.20.tgz",
+      "integrity": "sha512-RQmDfeYBtXV2FSId7dfA1hE6M/T6+g7wdbYnFQ47tw/gUBwV+CccLVejNmCGa9yLDitk83foeg8hl/3DjfYQ5g==",
       "cpu": [
         "arm64"
       ],
@@ -1627,9 +1629,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "15.5.12",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.5.12.tgz",
-      "integrity": "sha512-jSLvgdRRL/hrFAPqEjJf1fFguC719kmcptjNVDJl26BnJIpjL3KH5h6mzR4mAweociLQaqvt4UyzfbFjgAdDcw==",
+      "version": "15.5.20",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.5.20.tgz",
+      "integrity": "sha512-DkWLEdKajJwdGt27M3i1VEO2kelTvZrK6Pcb7JvW2BY+nofWm7FBsBNDj7g7Pr1NuQ5PLJvqEqYa20GTsBDnKQ==",
       "cpu": [
         "x64"
       ],
@@ -1643,9 +1645,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "15.5.12",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.5.12.tgz",
-      "integrity": "sha512-/uaF0WfmYqQgLfPmN6BvULwxY0dufI2mlN2JbOKqqceZh1G4hjREyi7pg03zjfyS6eqNemHAZPSoP84x17vo6w==",
+      "version": "15.5.20",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.5.20.tgz",
+      "integrity": "sha512-rAO5b7pKHvX+ExdmJskusDXTNbiNZfptifIPZItbUx+AOXxxTydVBsPt7Oz84DRd5mY8e0DcE8kvLj3AIfjE6w==",
       "cpu": [
         "x64"
       ],
@@ -1659,9 +1661,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "15.5.12",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.5.12.tgz",
-      "integrity": "sha512-xhsL1OvQSfGmlL5RbOmU+FV120urrgFpYLq+6U8C6KIym32gZT6XF/SDE92jKzzlPWskkbjOKCpqk5m4i8PEfg==",
+      "version": "15.5.20",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.5.20.tgz",
+      "integrity": "sha512-Hp3zFsN8N8Kj9+vY6L4vnZ9EtA9eXyATu0q4EfGbZTiocgPUNSfz8NWhym6xvaOmHpJ8EuoypuU1WejCPsTFtg==",
       "cpu": [
         "arm64"
       ],
@@ -1675,9 +1677,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "15.5.12",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.5.12.tgz",
-      "integrity": "sha512-Z1Dh6lhFkxvBDH1FoW6OU/L6prYwPSlwjLiZkExIAh8fbP6iI/M7iGTQAJPYJ9YFlWobCZ1PHbchFhFYb2ADkw==",
+      "version": "15.5.20",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.5.20.tgz",
+      "integrity": "sha512-T/L7CXpR1M0wij/xbF3rT1+7KvSkfOLr7C+ToHHWZTG2eKmb52C5WvsyGCBNtkVvDEUESWkRUbbqSH4rSbOCYQ==",
       "cpu": [
         "x64"
       ],
@@ -1770,9 +1772,9 @@
       "license": "MIT"
     },
     "node_modules/@oxc-project/types": {
-      "version": "0.124.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.124.0.tgz",
-      "integrity": "sha512-VBFWMTBvHxS11Z5Lvlr3IWgrwhMTXV+Md+EQF0Xf60+wAdsGFTBx7X7K/hP4pi8N7dcm1RvcHwDxZ16Qx8keUg==",
+      "version": "0.139.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.139.0.tgz",
+      "integrity": "sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -2111,9 +2113,9 @@
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.15.tgz",
-      "integrity": "sha512-YYe6aWruPZDtHNpwu7+qAHEMbQ/yRl6atqb/AhznLTnD3UY99Q1jE7ihLSahNWkF4EqRPVC4SiR4O0UkLK02tA==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.5.tgz",
+      "integrity": "sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ==",
       "cpu": [
         "arm64"
       ],
@@ -2128,9 +2130,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-arm64": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.15.tgz",
-      "integrity": "sha512-oArR/ig8wNTPYsXL+Mzhs0oxhxfuHRfG7Ikw7jXsw8mYOtk71W0OkF2VEVh699pdmzjPQsTjlD1JIOoHkLP1Fg==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.5.tgz",
+      "integrity": "sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw==",
       "cpu": [
         "arm64"
       ],
@@ -2145,9 +2147,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-x64": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.15.tgz",
-      "integrity": "sha512-YzeVqOqjPYvUbJSWJ4EDL8ahbmsIXQpgL3JVipmN+MX0XnXMeWomLN3Fb+nwCmP/jfyqte5I3XRSm7OfQrbyxw==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.5.tgz",
+      "integrity": "sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g==",
       "cpu": [
         "x64"
       ],
@@ -2162,9 +2164,9 @@
       }
     },
     "node_modules/@rolldown/binding-freebsd-x64": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.15.tgz",
-      "integrity": "sha512-9Erhx956jeQ0nNTyif1+QWAXDRD38ZNjr//bSHrt6wDwB+QkAfl2q6Mn1k6OBPerznjRmbM10lgRb1Pli4xZPw==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.5.tgz",
+      "integrity": "sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA==",
       "cpu": [
         "x64"
       ],
@@ -2179,9 +2181,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.15.tgz",
-      "integrity": "sha512-cVwk0w8QbZJGTnP/AHQBs5yNwmpgGYStL88t4UIaqcvYJWBfS0s3oqVLZPwsPU6M0zlW4GqjP0Zq5MnAGwFeGA==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.5.tgz",
+      "integrity": "sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw==",
       "cpu": [
         "arm"
       ],
@@ -2196,9 +2198,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-gnu": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.15.tgz",
-      "integrity": "sha512-eBZ/u8iAK9SoHGanqe/jrPnY0JvBN6iXbVOsbO38mbz+ZJsaobExAm1Iu+rxa4S1l2FjG0qEZn4Rc6X8n+9M+w==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.5.tgz",
+      "integrity": "sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q==",
       "cpu": [
         "arm64"
       ],
@@ -2213,9 +2215,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-musl": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.15.tgz",
-      "integrity": "sha512-ZvRYMGrAklV9PEkgt4LQM6MjQX2P58HPAuecwYObY2DhS2t35R0I810bKi0wmaYORt6m/2Sm+Z+nFgb0WhXNcQ==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.5.tgz",
+      "integrity": "sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==",
       "cpu": [
         "arm64"
       ],
@@ -2230,9 +2232,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.15.tgz",
-      "integrity": "sha512-VDpgGBzgfg5hLg+uBpCLoFG5kVvEyafmfxGUV0UHLcL5irxAK7PKNeC2MwClgk6ZAiNhmo9FLhRYgvMmedLtnQ==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.5.tgz",
+      "integrity": "sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg==",
       "cpu": [
         "ppc64"
       ],
@@ -2247,9 +2249,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-s390x-gnu": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.15.tgz",
-      "integrity": "sha512-y1uXY3qQWCzcPgRJATPSOUP4tCemh4uBdY7e3EZbVwCJTY3gLJWnQABgeUetvED+bt1FQ01OeZwvhLS2bpNrAQ==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.5.tgz",
+      "integrity": "sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==",
       "cpu": [
         "s390x"
       ],
@@ -2264,9 +2266,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-gnu": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.15.tgz",
-      "integrity": "sha512-023bTPBod7J3Y/4fzAN6QtpkSABR0rigtrwaP+qSEabUh5zf6ELr9Nc7GujaROuPY3uwdSIXWrvhn1KxOvurWA==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.5.tgz",
+      "integrity": "sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ==",
       "cpu": [
         "x64"
       ],
@@ -2281,9 +2283,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-musl": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.15.tgz",
-      "integrity": "sha512-witB2O0/hU4CgfOOKUoeFgQ4GktPi1eEbAhaLAIpgD6+ZnhcPkUtPsoKKHRzmOoWPZue46IThdSgdo4XneOLYw==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.5.tgz",
+      "integrity": "sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==",
       "cpu": [
         "x64"
       ],
@@ -2298,9 +2300,9 @@
       }
     },
     "node_modules/@rolldown/binding-openharmony-arm64": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.15.tgz",
-      "integrity": "sha512-UCL68NJ0Ud5zRipXZE9dF5PmirzJE4E4BCIOOssEnM7wLDsxjc6Qb0sGDxTNRTP53I6MZpygyCpY8Aa8sPfKPg==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.5.tgz",
+      "integrity": "sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw==",
       "cpu": [
         "arm64"
       ],
@@ -2315,9 +2317,9 @@
       }
     },
     "node_modules/@rolldown/binding-wasm32-wasi": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.15.tgz",
-      "integrity": "sha512-ApLruZq/ig+nhaE7OJm4lDjayUnOHVUa77zGeqnqZ9pn0ovdVbbNPerVibLXDmWeUZXjIYIT8V3xkT58Rm9u5Q==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.5.tgz",
+      "integrity": "sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA==",
       "cpu": [
         "wasm32"
       ],
@@ -2325,23 +2327,23 @@
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/core": "1.9.2",
-        "@emnapi/runtime": "1.9.2",
-        "@napi-rs/wasm-runtime": "^1.1.3"
+        "@emnapi/core": "1.11.1",
+        "@emnapi/runtime": "1.11.1",
+        "@napi-rs/wasm-runtime": "^1.1.6"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": "^20.19.0 || >=22.12.0"
       }
     },
     "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
-      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
+      "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@tybys/wasm-util": "^0.10.1"
+        "@tybys/wasm-util": "^0.10.3"
       },
       "funding": {
         "type": "github",
@@ -2353,9 +2355,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.15.tgz",
-      "integrity": "sha512-KmoUoU7HnN+Si5YWJigfTws1jz1bKBYDQKdbLspz0UaqjjFkddHsqorgiW1mxcAj88lYUE6NC/zJNwT+SloqtA==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.5.tgz",
+      "integrity": "sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw==",
       "cpu": [
         "arm64"
       ],
@@ -2370,9 +2372,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-x64-msvc": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.15.tgz",
-      "integrity": "sha512-3P2A8L+x75qavWLe/Dll3EYBJLQmtkJN8rfh+U/eR3MqMgL/h98PhYI+JFfXuDPgPeCB7iZAKiqii5vqOvnA0g==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.5.tgz",
+      "integrity": "sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA==",
       "cpu": [
         "x64"
       ],
@@ -2857,9 +2859,9 @@
       }
     },
     "node_modules/@tybys/wasm-util": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
-      "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -3228,9 +3230,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3268,13 +3270,13 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "^2.0.2"
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -3756,10 +3758,22 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
     "node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3771,6 +3785,22 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ansi-escapes": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.3.0.tgz",
+      "integrity": "sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "environment": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/ansi-regex": {
@@ -4037,14 +4067,15 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.12.2.tgz",
-      "integrity": "sha512-vMJzPewAlRyOgxV2dU0Cuz2O8zzzx9VYtbJOaBgXFeLc4IV/Eg50n4LowmehOOR61S8ZMpc2K5Sa7g6A4jfkUw==",
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.18.1.tgz",
+      "integrity": "sha512-3nTvFlvpn9Zu/RkHUqtc7/+al4UpRW5az71ap5zccp6e8RAYEzhMTecX8Dz1wWDYrPpUoB1HAQEGEAEvUr7S9g==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.4",
-        "proxy-from-env": "^1.1.0"
+        "follow-redirects": "^1.16.0",
+        "form-data": "^4.0.5",
+        "https-proxy-agent": "^5.0.1",
+        "proxy-from-env": "^2.1.0"
       }
     },
     "node_modules/axobject-query": {
@@ -4075,9 +4106,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4214,6 +4245,39 @@
         "node": ">=18"
       }
     },
+    "node_modules/cli-cursor": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
+      "integrity": "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "restore-cursor": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-truncate": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-5.2.0.tgz",
+      "integrity": "sha512-xRwvIOMGrfOAnM1JYtqQImuaNtDEv9v6oIYAs4LIHwTiKee8uwvIi363igssOC0O5U04i4AlENs79LQLu9tEMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "slice-ansi": "^8.0.0",
+        "string-width": "^8.2.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/client-only": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
@@ -4276,14 +4340,14 @@
       "license": "MIT"
     },
     "node_modules/convex": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/convex/-/convex-1.32.0.tgz",
-      "integrity": "sha512-5FlajdLpW75pdLS+/CgGH5H6yeRuA+ru50AKJEYbJpmyILUS+7fdTvsdTaQ7ZFXMv0gE8mX4S+S3AtJ94k0mfw==",
+      "version": "1.42.1",
+      "resolved": "https://registry.npmjs.org/convex/-/convex-1.42.1.tgz",
+      "integrity": "sha512-yFKp4xerVuBwQqpuTtvosOk9F/fX0twZs+Xti3oj/MlwPUU90QuhgCYo/I2wvFBAFwXsmx9tXpf2q8ekh1+3ug==",
       "license": "Apache-2.0",
       "dependencies": {
         "esbuild": "0.27.0",
         "prettier": "^3.0.0",
-        "ws": "8.18.0"
+        "ws": "8.21.0"
       },
       "bin": {
         "convex": "bin/main.js"
@@ -4295,6 +4359,7 @@
       "peerDependencies": {
         "@auth0/auth0-react": "^2.0.1",
         "@clerk/clerk-react": "^4.12.8 || ^5.0.0",
+        "@clerk/react": "^6.4.3",
         "react": "^18.0.0 || ^19.0.0-0 || ^19.0.0"
       },
       "peerDependenciesMeta": {
@@ -4304,28 +4369,10 @@
         "@clerk/clerk-react": {
           "optional": true
         },
-        "react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/convex/node_modules/ws": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
-      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
+        "@clerk/react": {
           "optional": true
         },
-        "utf-8-validate": {
+        "react": {
           "optional": true
         }
       }
@@ -4591,7 +4638,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -4821,6 +4867,19 @@
       },
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/environment": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/environment/-/environment-1.1.0.tgz",
+      "integrity": "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/es-abstract": {
@@ -5129,13 +5188,13 @@
       }
     },
     "node_modules/eslint-config-next": {
-      "version": "15.5.3",
-      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-15.5.3.tgz",
-      "integrity": "sha512-e6j+QhQFOr5pfsc8VJbuTD9xTXJaRvMHYjEeLPA2pFkheNlgPLCkxdvhxhfuM4KGcqSZj2qEnpHisdTVs3BxuQ==",
+      "version": "15.5.20",
+      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-15.5.20.tgz",
+      "integrity": "sha512-Pl/I5544gmkcVVWcnaOMfhJSBK8lZ1NCJ+mGBkd2qvbGt2Gi7sEpgHF06OR13a2p6THODlncpvGsZzY2vUqwxw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@next/eslint-plugin-next": "15.5.3",
+        "@next/eslint-plugin-next": "15.5.20",
         "@rushstack/eslint-patch": "^1.10.3",
         "@typescript-eslint/eslint-plugin": "^5.4.2 || ^6.0.0 || ^7.0.0 || ^8.0.0",
         "@typescript-eslint/parser": "^5.4.2 || ^6.0.0 || ^7.0.0 || ^8.0.0",
@@ -5504,9 +5563,9 @@
       }
     },
     "node_modules/eventemitter3": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
-      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
       "license": "MIT"
     },
     "node_modules/expect-type": {
@@ -5638,16 +5697,16 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "funding": [
         {
           "type": "individual",
@@ -5681,16 +5740,16 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
-      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
       },
       "engines": {
         "node": ">= 6"
@@ -5801,6 +5860,19 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-east-asian-width": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/get-intrinsic": {
@@ -6026,9 +6098,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -6101,6 +6173,35 @@
         "domhandler": "^5.0.3",
         "domutils": "^3.0.1",
         "entities": "^4.4.0"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/husky": {
+      "version": "9.1.7",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
+      "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "husky": "bin.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
       }
     },
     "node_modules/ignore": {
@@ -6353,6 +6454,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.1.0.tgz",
+      "integrity": "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-generator-function": {
@@ -6663,10 +6780,20 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -7088,6 +7215,61 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/lint-staged": {
+      "version": "17.0.8",
+      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-17.0.8.tgz",
+      "integrity": "sha512-B2P/d+jVW0UXOQ0MVMLrB/9ydA1P+zz6jYfdrbbEd9ur3S2rcbduFWKiUCC02Sm5hbC8nrm7y24WuYMG54HfxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "listr2": "^10.2.1",
+        "picomatch": "^4.0.4",
+        "string-argv": "^0.3.2",
+        "tinyexec": "^1.2.4"
+      },
+      "bin": {
+        "lint-staged": "bin/lint-staged.js"
+      },
+      "engines": {
+        "node": ">=22.22.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/lint-staged"
+      },
+      "optionalDependencies": {
+        "yaml": "^2.9.0"
+      }
+    },
+    "node_modules/lint-staged/node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/listr2": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/listr2/-/listr2-10.2.2.tgz",
+      "integrity": "sha512-JtNtbZj8q5BnDMR7trpwvwk3RIrANtIVzEUm8w7amp6xelLgyuq+4WZoTH913XaQAoH/cNdYhaNzBPA2U3xbDw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cli-truncate": "^5.2.0",
+        "eventemitter3": "^5.0.4",
+        "log-update": "^6.1.0",
+        "rfdc": "^1.4.1",
+        "wrap-ansi": "^10.0.0"
+      },
+      "engines": {
+        "node": ">=22.13.0"
+      }
+    },
     "node_modules/locate-path": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -7105,15 +7287,15 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
     },
     "node_modules/lodash-es": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
-      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
+      "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
       "license": "MIT"
     },
     "node_modules/lodash.merge": {
@@ -7122,6 +7304,99 @@
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/log-update": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/log-update/-/log-update-6.1.0.tgz",
+      "integrity": "sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-escapes": "^7.0.0",
+        "cli-cursor": "^5.0.0",
+        "slice-ansi": "^7.1.0",
+        "strip-ansi": "^7.1.0",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-update/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/log-update/node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/log-update/node_modules/slice-ansi": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-7.1.2.tgz",
+      "integrity": "sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "is-fullwidth-code-point": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/log-update/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-update/node_modules/wrap-ansi": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
     },
     "node_modules/loose-envify": {
       "version": "1.4.0",
@@ -7272,6 +7547,19 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/mimic-function": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
+      "integrity": "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/min-indent": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
@@ -7283,9 +7571,9 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -7316,9 +7604,9 @@
       }
     },
     "node_modules/minizlib": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.0.2.tgz",
-      "integrity": "sha512-oG62iEk+CYt5Xj2YqI5Xi9xWUeZhDI8jjQmC5oThVH5JGCTgIjr7ciJDzC7MBzYd//WvR1OTmP5Q38Q8ShQtVA==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
+      "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7326,22 +7614,6 @@
       },
       "engines": {
         "node": ">= 18"
-      }
-    },
-    "node_modules/mkdirp": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-3.0.1.tgz",
-      "integrity": "sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "mkdirp": "dist/cjs/src/bin.js"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/motion-dom": {
@@ -7363,13 +7635,12 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "funding": [
         {
           "type": "github",
@@ -7408,12 +7679,12 @@
       "license": "MIT"
     },
     "node_modules/next": {
-      "version": "15.5.12",
-      "resolved": "https://registry.npmjs.org/next/-/next-15.5.12.tgz",
-      "integrity": "sha512-Fi/wQ4Etlrn60rz78bebG1i1SR20QxvV8tVp6iJspjLUSHcZoeUXCt+vmWoEcza85ElZzExK/jJ/F6SvtGktjA==",
+      "version": "15.5.20",
+      "resolved": "https://registry.npmjs.org/next/-/next-15.5.20.tgz",
+      "integrity": "sha512-cvyS3/geydan1xLtE3FA8VCgdoQ/Gg/dlOldFkFCbB5VcVYJV7090hQLBnvTW2PwT76Z/dHdzDZCsVhZpoOlUA==",
       "license": "MIT",
       "dependencies": {
-        "@next/env": "15.5.12",
+        "@next/env": "15.5.20",
         "@swc/helpers": "0.5.15",
         "caniuse-lite": "^1.0.30001579",
         "postcss": "8.4.31",
@@ -7426,14 +7697,14 @@
         "node": "^18.18.0 || ^19.8.0 || >= 20.0.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "15.5.12",
-        "@next/swc-darwin-x64": "15.5.12",
-        "@next/swc-linux-arm64-gnu": "15.5.12",
-        "@next/swc-linux-arm64-musl": "15.5.12",
-        "@next/swc-linux-x64-gnu": "15.5.12",
-        "@next/swc-linux-x64-musl": "15.5.12",
-        "@next/swc-win32-arm64-msvc": "15.5.12",
-        "@next/swc-win32-x64-msvc": "15.5.12",
+        "@next/swc-darwin-arm64": "15.5.20",
+        "@next/swc-darwin-x64": "15.5.20",
+        "@next/swc-linux-arm64-gnu": "15.5.20",
+        "@next/swc-linux-arm64-musl": "15.5.20",
+        "@next/swc-linux-x64-gnu": "15.5.20",
+        "@next/swc-linux-x64-musl": "15.5.20",
+        "@next/swc-win32-arm64-msvc": "15.5.20",
+        "@next/swc-win32-x64-msvc": "15.5.20",
         "sharp": "^0.34.3"
       },
       "peerDependencies": {
@@ -7630,6 +7901,22 @@
       ],
       "license": "MIT"
     },
+    "node_modules/onetime": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz",
+      "integrity": "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-function": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -7806,9 +8093,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7876,9 +8163,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.10",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
-      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
+      "version": "8.5.18",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.18.tgz",
+      "integrity": "sha512-xdB1oSLHbz1vRWgCDalrCqEFTWzFlhqFC5tIHLMOSUIjhm3XXQ1qrFy8S/ESr1JYRRXqM3c1QFiMZUJdUTqyMQ==",
       "dev": true,
       "funding": [
         {
@@ -7896,7 +8183,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -7985,10 +8272,13 @@
       "license": "MIT"
     },
     "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "license": "MIT"
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/punycode": {
       "version": "2.3.1",
@@ -8266,6 +8556,23 @@
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
       }
     },
+    "node_modules/restore-cursor": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz",
+      "integrity": "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "onetime": "^7.0.0",
+        "signal-exit": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/reusify": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
@@ -8277,15 +8584,22 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/rfdc": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
+      "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/rolldown": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.15.tgz",
-      "integrity": "sha512-Ff31guA5zT6WjnGp0SXw76X6hzGRk/OQq2hE+1lcDe+lJdHSgnSX6nK3erbONHyCbpSj9a9E+uX/OvytZoWp2g==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.5.tgz",
+      "integrity": "sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@oxc-project/types": "=0.124.0",
-        "@rolldown/pluginutils": "1.0.0-rc.15"
+        "@oxc-project/types": "=0.139.0",
+        "@rolldown/pluginutils": "^1.0.0"
       },
       "bin": {
         "rolldown": "bin/cli.mjs"
@@ -8294,27 +8608,27 @@
         "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@rolldown/binding-android-arm64": "1.0.0-rc.15",
-        "@rolldown/binding-darwin-arm64": "1.0.0-rc.15",
-        "@rolldown/binding-darwin-x64": "1.0.0-rc.15",
-        "@rolldown/binding-freebsd-x64": "1.0.0-rc.15",
-        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.15",
-        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.15",
-        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.15",
-        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.15",
-        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.15",
-        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.15",
-        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.15",
-        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.15",
-        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.15",
-        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.15",
-        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.15"
+        "@rolldown/binding-android-arm64": "1.1.5",
+        "@rolldown/binding-darwin-arm64": "1.1.5",
+        "@rolldown/binding-darwin-x64": "1.1.5",
+        "@rolldown/binding-freebsd-x64": "1.1.5",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.1.5",
+        "@rolldown/binding-linux-arm64-gnu": "1.1.5",
+        "@rolldown/binding-linux-arm64-musl": "1.1.5",
+        "@rolldown/binding-linux-ppc64-gnu": "1.1.5",
+        "@rolldown/binding-linux-s390x-gnu": "1.1.5",
+        "@rolldown/binding-linux-x64-gnu": "1.1.5",
+        "@rolldown/binding-linux-x64-musl": "1.1.5",
+        "@rolldown/binding-openharmony-arm64": "1.1.5",
+        "@rolldown/binding-wasm32-wasi": "1.1.5",
+        "@rolldown/binding-win32-arm64-msvc": "1.1.5",
+        "@rolldown/binding-win32-x64-msvc": "1.1.5"
       }
     },
     "node_modules/rolldown/node_modules/@rolldown/pluginutils": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.15.tgz",
-      "integrity": "sha512-UromN0peaE53IaBRe9W7CjrZgXl90fqGpK+mIZbA3qSTeYqg3pqpROBdIPvOG3F5ereDHNwoHBI2e50n1BDr1g==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
       "dev": true,
       "license": "MIT"
     },
@@ -8645,6 +8959,49 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/slice-ansi": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-8.0.0.tgz",
+      "integrity": "sha512-stxByr12oeeOyY2BlviTNQlYV5xOj47GirPr4yA1hE9JCtxfQN0+tVbkxwCtYDQWhEKWFHsEK48ORg5jrouCAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.3",
+        "is-fullwidth-code-point": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/slice-ansi/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/sonner": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/sonner/-/sonner-2.0.7.tgz",
@@ -8697,6 +9054,33 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/string-argv": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.3.2.tgz",
+      "integrity": "sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6.19"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.2.tgz",
+      "integrity": "sha512-GaPUh5gfdrYzqeVNZvUfT23vYYxXzKYidUcnMtJg/3rxRV63EFZy3k6xfKlmfeJD0176lnUV/Usr3XcwSvFzpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.5.0",
+        "strip-ansi": "^7.1.2"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/string.prototype.includes": {
@@ -8810,6 +9194,35 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-ansi/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
       }
     },
     "node_modules/strip-bom": {
@@ -8936,17 +9349,16 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.4.3.tgz",
-      "integrity": "sha512-5S7Va8hKfV7W5U6g3aYxXmlPoZVAwUMy9AOKyF2fVuZa2UD3qZjg578OrLRt8PcNN1PleVaL/5/yYATNL0ICUw==",
+      "version": "7.5.20",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.20.tgz",
+      "integrity": "sha512-9FcyK4PA6+WbzlTM9WhQm6vB5W7cP7dUiPsv1g7YDwEQnQ1CGpK3MGlKk/ITVWMk05kHZuBhmVhiv8LZoy/PFQ==",
       "dev": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",
         "chownr": "^3.0.0",
         "minipass": "^7.1.2",
-        "minizlib": "^3.0.1",
-        "mkdirp": "^3.0.1",
+        "minizlib": "^3.1.0",
         "yallist": "^5.0.0"
       },
       "engines": {
@@ -8979,9 +9391,9 @@
       "license": "MIT"
     },
     "node_modules/tinyexec": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.1.tgz",
-      "integrity": "sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -8989,14 +9401,14 @@
       }
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.15",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
-      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
-        "picomatch": "^4.0.3"
+        "picomatch": "^4.0.4"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -9024,9 +9436,9 @@
       }
     },
     "node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -9280,9 +9692,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.25.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
-      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -9373,17 +9785,17 @@
       }
     },
     "node_modules/vite": {
-      "version": "8.0.8",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.8.tgz",
-      "integrity": "sha512-dbU7/iLVa8KZALJyLOBOQ88nOXtNG8vxKuOT4I2mD+Ya70KPceF4IAmDsmU0h1Qsn5bPrvsY9HJstCRh3hG6Uw==",
+      "version": "8.1.4",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.4.tgz",
+      "integrity": "sha512-bTT9PsdWO+MQMNG9ZXIP/qM9wGh37DFxTV/sPq9cFpHr3w4jkgef032PkAL9jAqhk3Nz8NQw3O8n6/xFkqO4QQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "lightningcss": "^1.32.0",
-        "picomatch": "^4.0.4",
-        "postcss": "^8.5.8",
-        "rolldown": "1.0.0-rc.15",
-        "tinyglobby": "^0.2.15"
+        "picomatch": "^4.0.5",
+        "postcss": "^8.5.16",
+        "rolldown": "~1.1.4",
+        "tinyglobby": "^0.2.17"
       },
       "bin": {
         "vite": "bin/vite.js"
@@ -9399,7 +9811,7 @@
       },
       "peerDependencies": {
         "@types/node": "^20.19.0 || >=22.12.0",
-        "@vitejs/devtools": "^0.1.0",
+        "@vitejs/devtools": "^0.3.0",
         "esbuild": "^0.27.0 || ^0.28.0",
         "jiti": ">=1.21.0",
         "less": "^4.0.0",
@@ -9691,9 +10103,9 @@
       }
     },
     "node_modules/vite/node_modules/picomatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -9986,6 +10398,58 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/wrap-ansi": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-10.0.0.tgz",
+      "integrity": "sha512-SGcvg80f0wUy2/fXES19feHMz8E0JoXv2uNgHOu4Dgi2OrCy1lqwFYEJz1BLbDI0exjPMe/ZdzZ/YpGECBG/aQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.3",
+        "string-width": "^8.2.0",
+        "strip-ansi": "^7.1.2"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/xml-name-validator": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
@@ -10011,6 +10475,23 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -6,13 +6,26 @@
     "dev": "next dev --turbopack",
     "build": "next build --turbopack",
     "start": "next start",
-    "lint": "eslint",
+    "lint": "eslint --max-warnings 48",
+    "lint:staged": "lint-staged",
     "type-check": "tsc --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",
     "test:backend": "vitest run --project backend",
     "test:frontend": "vitest run --project frontend",
-    "test:e2e": "playwright test"
+    "test:e2e": "playwright test",
+    "verify:commit": "lint-staged",
+    "verify:push": "npm run lint && npm run type-check && npm run test && npm run build",
+    "verify": "npm run verify:push",
+    "verify:full": "npm run verify:push && npm run test:e2e",
+    "prepare": "husky"
+  },
+  "lint-staged": {
+    "*.{ts,tsx,js,mjs}": "eslint",
+    "*.{json,md,css}": "git diff --check --"
+  },
+  "overrides": {
+    "picomatch@2.3.1": "2.3.2"
   },
   "dependencies": {
     "@auth/core": "^0.37.0",
@@ -27,7 +40,7 @@
     "framer-motion": "^12.23.16",
     "gsap": "^3.13.0",
     "lucide-react": "^0.544.0",
-    "next": "15.5.12",
+    "next": "^15.5.20",
     "react": "19.1.0",
     "react-dom": "19.1.0",
     "recharts": "^3.2.1",
@@ -50,8 +63,10 @@
     "@types/react-dom": "^19",
     "@vitejs/plugin-react": "^6.0.1",
     "eslint": "^9",
-    "eslint-config-next": "15.5.3",
+    "eslint-config-next": "^15.5.20",
+    "husky": "^9.1.7",
     "jsdom": "^29.0.2",
+    "lint-staged": "^17.0.8",
     "tailwindcss": "^4",
     "typescript": "^5",
     "vitest": "^4.1.4"

--- a/scripts/run-migration.mjs
+++ b/scripts/run-migration.mjs
@@ -18,13 +18,21 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 // ─── Config ──────────────────────────────────────────────────────────────────
 
-const CONVEX_URL = "https://acrobatic-swordfish-996.convex.cloud";
+const CONVEX_URL = process.env.NEXT_PUBLIC_CONVEX_URL;
+const MIGRATION_SECRET = process.env.MIGRATION_SECRET;
 const EXPORT_FILE = path.join(__dirname, "supabase-export.json");
 const READING_BATCH_SIZE = 50; // Keep batches small to stay under Convex argument limits
 
 // ─── Main ────────────────────────────────────────────────────────────────────
 
 async function main() {
+  if (!CONVEX_URL || !MIGRATION_SECRET) {
+    console.error(
+      "NEXT_PUBLIC_CONVEX_URL and MIGRATION_SECRET must be set before migration"
+    );
+    process.exit(1);
+  }
+
   const userId = process.argv[2];
   if (!userId) {
     console.error("Usage: node scripts/run-migration.mjs <convex-user-id>");
@@ -54,6 +62,7 @@ async function main() {
   // Step 1: Import devices (small payload — call runMigration with only devices)
   console.log(`📦 Step 1: Importing ${data.devices.length} devices...`);
   const devicesResult = await client.action("migrations:runMigration", {
+    migrationSecret: MIGRATION_SECRET,
     userId,
     data: {
       devices: data.devices,
@@ -89,6 +98,7 @@ async function main() {
 
       try {
         const result = await client.action("migrations:runMigration", {
+          migrationSecret: MIGRATION_SECRET,
           userId,
           data: {
             devices: data.devices, // Always include for ID mapping (idempotent)
@@ -105,6 +115,7 @@ async function main() {
           const smallBatch = batch.slice(j, j + smallBatchSize);
           try {
             await client.action("migrations:runMigration", {
+              migrationSecret: MIGRATION_SECRET,
               userId,
               data: {
                 devices: data.devices,
@@ -125,6 +136,7 @@ async function main() {
   if ((data.settings?.length > 0) || (data.dailySummaries?.length > 0) || (data.alerts?.length > 0)) {
     console.log(`\n📦 Step 3: Importing settings/summaries/alerts...`);
     const extraResult = await client.action("migrations:runMigration", {
+      migrationSecret: MIGRATION_SECRET,
       userId,
       data: {
         devices: data.devices,

--- a/src/app/(dashboard)/device/[deviceId]/settings/page.tsx
+++ b/src/app/(dashboard)/device/[deviceId]/settings/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useRef, useCallback, use } from 'react';
+import { useState, useCallback, use } from 'react';
 import { useRouter } from 'next/navigation';
 import { useConvexDevices, useConvexDeviceMutations, useConvexDeviceControl, useConvexSchedules } from '@/hooks/useConvexData';
 import Link from 'next/link';
@@ -59,19 +59,24 @@ export default function DeviceSettingsPage({ params }: DeviceSettingsPageProps) 
   // DC charging current slider state
   const [dcSliderValue, setDcSliderValue] = useState<number | null>(null);
   const [isDragging, setIsDragging] = useState(false);
-  const sliderRef = useRef<HTMLInputElement>(null);
 
   const dcCurrentDisplay = dcSliderValue ?? reading?.dcChargingCurrent ?? 8000;
 
   const handleDcSliderCommit = useCallback(async (val: number) => {
+    if (!device) {
+      toast.error('Device is not available yet');
+      setDcSliderValue(null);
+      return;
+    }
+
     try {
-      await deviceControl.setChargingConfig({ deviceSn: device?.deviceSn ?? '', dcChgCurrent: val });
+      await deviceControl.setChargingConfig({ deviceSn: device.deviceSn, dcChgCurrent: val });
       toast.success(`DC input current set to ${val / 1000}A`);
     } catch (err) {
       toast.error(err instanceof Error ? err.message : 'Failed');
     }
     setDcSliderValue(null);
-  }, [deviceControl, device?.deviceSn]);
+  }, [deviceControl, device]);
 
   const [formData, setFormData] = useState({
     deviceName: '',
@@ -650,7 +655,6 @@ export default function DeviceSettingsPage({ params }: DeviceSettingsPageProps) 
                               </div>
                             )}
                             <input
-                              ref={sliderRef}
                               type="range"
                               min={4000}
                               max={10000}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,4 +1,4 @@
-import type { Metadata } from 'next'
+import type { Metadata, Viewport } from 'next'
 import localFont from 'next/font/local'
 import { Toaster } from 'sonner'
 import { ConvexClientProvider } from '@/components/ConvexClientProvider'
@@ -25,15 +25,16 @@ export const metadata: Metadata = {
   description: 'Monitor and manage your EcoFlow Delta 2 power station',
   keywords: ['EcoFlow', 'Delta 2', 'Power Station', 'Battery Monitor', 'Energy Management'],
   authors: [{ name: 'EcoFlow Dashboard' }],
-  viewport: {
-    width: 'device-width',
-    initialScale: 1,
-    maximumScale: 1,
-    userScalable: false,
-    viewportFit: 'cover'
-  },
-  themeColor: '#44af21',
   manifest: '/manifest.json',
+}
+
+export const viewport: Viewport = {
+  width: 'device-width',
+  initialScale: 1,
+  maximumScale: 1,
+  userScalable: false,
+  viewportFit: 'cover',
+  themeColor: '#44af21',
 }
 
 export default function RootLayout({

--- a/src/components/ui/PillButton.test.tsx
+++ b/src/components/ui/PillButton.test.tsx
@@ -1,0 +1,30 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { PillButton } from "./PillButton";
+
+describe("PillButton", () => {
+  it("uses button semantics and handles activation", async () => {
+    const user = userEvent.setup();
+    const onClick = vi.fn();
+    render(<PillButton onClick={onClick}>Save settings</PillButton>);
+
+    await user.click(screen.getByRole("button", { name: "Save settings" }));
+
+    expect(onClick).toHaveBeenCalledOnce();
+  });
+
+  it("does not activate when disabled", async () => {
+    const user = userEvent.setup();
+    const onClick = vi.fn();
+    render(
+      <PillButton onClick={onClick} disabled>
+        Save settings
+      </PillButton>
+    );
+
+    await user.click(screen.getByRole("button", { name: "Save settings" }));
+
+    expect(onClick).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/ui/Toggle.test.tsx
+++ b/src/components/ui/Toggle.test.tsx
@@ -1,0 +1,28 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { Toggle } from "./Toggle";
+
+describe("Toggle", () => {
+  it("reports the next checked state when activated", async () => {
+    const user = userEvent.setup();
+    const onToggle = vi.fn();
+    render(<Toggle checked={false} onToggle={onToggle} label="AC output" />);
+
+    await user.click(screen.getByRole("checkbox", { name: "AC output" }));
+
+    expect(onToggle).toHaveBeenCalledWith(true);
+  });
+
+  it("does not activate while disabled", async () => {
+    const user = userEvent.setup();
+    const onToggle = vi.fn();
+    render(
+      <Toggle checked={false} onToggle={onToggle} label="DC output" disabled />
+    );
+
+    await user.click(screen.getByRole("checkbox", { name: "DC output" }));
+
+    expect(onToggle).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/data-utils.test.ts
+++ b/src/lib/data-utils.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import {
+  formatBatteryLevel,
+  formatDeviceStatus,
+  formatPowerValue,
+  formatRemainingTime,
+  formatTemperature,
+} from "./data-utils";
+
+describe("data formatting utilities", () => {
+  it("formats power using watts and kilowatts", () => {
+    expect(formatPowerValue(999)).toBe("999W");
+    expect(formatPowerValue(1_250)).toBe("1.3kW");
+  });
+
+  it("rounds battery and temperature values for display", () => {
+    expect(formatBatteryLevel(74.6)).toBe("75%");
+    expect(formatTemperature(25.4)).toBe("25°C");
+    expect(formatTemperature(0, "F")).toBe("32°F");
+  });
+
+  it("preserves the signed remaining-time convention", () => {
+    expect(formatRemainingTime(95)).toBe("1h 35m until full");
+    expect(formatRemainingTime(-1_500)).toBe("1d 1h remaining");
+    expect(formatRemainingTime(0)).toBe("N/A");
+    expect(formatRemainingTime(null)).toBe("N/A");
+  });
+
+  it("returns a safe fallback for unknown device status", () => {
+    expect(formatDeviceStatus("unexpected")).toEqual({
+      label: "Unknown",
+      color: "gray",
+      icon: "unknown",
+    });
+  });
+});

--- a/src/lib/data-utils.ts
+++ b/src/lib/data-utils.ts
@@ -34,6 +34,9 @@ export interface DeviceReading {
   status?: string | null
   rawData?: Record<string, unknown>
   recordedAt: Date | number
+  acChargingWatts?: number | null
+  acChargingPaused?: boolean | null
+  dcChargingCurrent?: number | null
 }
 
 // ─── Formatting Utilities ─────────────────────────────────────────────────────

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -43,6 +43,7 @@ export interface DeviceReading {
   acOutVoltage?: number
   acOutFrequency?: number
   acChargingWatts?: number
+  acChargingPaused?: boolean
   dcChargingCurrent?: number
   acStandbyMins?: number
   carStandbyMins?: number

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,1 +1,7 @@
 import "@testing-library/jest-dom/vitest";
+import { cleanup } from "@testing-library/react";
+import { afterEach } from "vitest";
+
+afterEach(() => {
+  cleanup();
+});


### PR DESCRIPTION
## Problem and outcome

Engineering conventions existed across Copilot instructions, hooks, configuration, and source patterns, but they were not consistently documented or enforced. This PR establishes a reproducible local quality gate, adds the first meaningful regression-test baseline, secures legacy migration tooling, and synchronizes repository guidance with the current architecture.

## What changed

- Adds Husky-managed pre-commit and pre-push hooks.
- Adds `verify`, `verify:push`, and `verify:full` scripts plus lint-staged checks.
- Enforces the current 48-warning ESLint ceiling so new warnings fail the push gate.
- Adds 16 backend, utility, and component tests covering EcoFlow signing and transforms, migration authorization, formatting, and core UI controls.
- Preserves AC charging pause state through schema, persistence, query, optimistic update, and client types.
- Guards legacy migrations with a one-time `MIGRATION_SECRET` and removes the hard-coded Convex deployment URL.
- Updates Next.js and affected dependencies, reducing audit findings from 18 to two moderate transitive PostCSS advisories.
- Moves viewport metadata to Next.js's supported export and restores linting during builds.
- Adds `AGENTS.md`, living `MEMORY.md`, a PR template, and synchronized README/Copilot guidance.

## Developer impact

After `npm install`, commits lint staged files and pushes run lint, type-checking, all Vitest projects, and a production build. GitHub Actions are not required for the baseline workflow. Durable architecture changes are expected to update `MEMORY.md` in the same PR.

## Verification

- [x] `npm run lint` — 0 errors; 48-warning ceiling satisfied
- [x] `npm run type-check`
- [x] `npm run test` — 16 tests passed across 5 files
- [x] `npm run build`
- [ ] `npm run test:e2e` — no authenticated E2E fixtures/scenarios exist yet

## Known follow-up work

- Reduce the ESLint warning ceiling from 48 toward zero.
- Add Convex database-handler, scheduling, and authenticated Playwright coverage.
- Remove or internalize the legacy migration surface after migration work is retired.
- Reassess the two remaining moderate transitive PostCSS advisories during the next framework upgrade.

## Deployment and migration notes

Run `npm install` after checkout so the Husky `prepare` script installs local hooks. Existing deployments need no data migration. `MIGRATION_SECRET` is only required when deliberately running the legacy Supabase-to-Convex importer and should be removed or rotated afterward.
