### PR TITLE
fix: prevent filtered history query failures

### DIFF
--- a/.env.e2e.example
+++ b/.env.e2e.example
@@ -1,0 +1,15 @@
+# Copy this file to .env.e2e.local and replace every placeholder.
+# Never commit .env.e2e.local or reuse production credentials.
+
+# Dedicated Convex E2E deployment
+NEXT_PUBLIC_CONVEX_URL=https://your-e2e-deployment.convex.cloud
+CONVEX_DEPLOYMENT=dev:your-e2e-deployment
+
+# Dedicated E2E identity
+E2E_USER_EMAIL=replace-with-e2e-user@example.test
+E2E_USER_PASSWORD=replace-with-a-test-only-password
+
+# In the dedicated Convex deployment dashboard, set DISABLE_CRONS=true and do
+# not configure ECOFLOW_ACCESS_KEY, ECOFLOW_SECRET_KEY, or RESEND_API_KEY.
+# The application has no runtime API/email mock mode; missing credentials are
+# the guard that prevents E2E runs from controlling devices or sending email.

--- a/MEMORY.md
+++ b/MEMORY.md
@@ -104,7 +104,7 @@ The collection cron is only a tick: each user's `collectionIntervalMinutes` dete
 - New readings are pushed through Convex reactivity; there is no normal client polling loop.
 - `useOnDemandRefresh` refreshes on focus, visibility, and navigation, with a two-minute client cooldown. The server independently skips fresh devices using the same approximate staleness threshold.
 - Device detail/settings routes refresh only that device; other routes may refresh all owned devices.
-- `readings.history` caps future end times to now, uses the compound index, limits rows adaptively, reads newest records first, reverses to chronological order, then aggregates.
+- `readings.history` caps future end times to now, rejects empty/inverted ranges, and uses the compound index. Ranges within the 500-document safety bound read normally; larger ranges fetch one evenly distributed indexed sample per window before aggregation so the entire interval remains represented. The bound protects Convex query limits because retained legacy readings may include large raw EcoFlow payloads; new inserts omit that unused payload.
 
 ### EcoFlow integration
 
@@ -163,7 +163,7 @@ Recent committed work leading into this state added full device control/schedule
 12. `migrations.runMigration` remains public for the legacy script, although it is now guarded by `MIGRATION_SECRET`. Prefer internalizing or deleting the migration surface once it is no longer needed.
 13. `npm audit` reports two moderate PostCSS advisories nested under Next.js. The remaining automatic remedy proposes a breaking/invalid Next downgrade, so it was not forced; reassess during the next framework upgrade.
 
-Current quality baseline at this update: `npm run type-check` passes; all 16 tests pass; `npm run lint` has a ceiling of 48 existing warnings and zero errors. The warnings are chiefly legacy `any`, unused imports/variables, the anonymous auth-config export, and two generated JavaScript eslint directives. Reduce the ceiling whenever warnings are repaired; the target is zero.
+Current quality baseline at this update: `npm run type-check` passes; all 22 tests pass; `npm run lint` has a ceiling of 48 existing warnings and zero errors. The warnings are chiefly legacy `any`, unused imports/variables, the anonymous auth-config export, and two generated JavaScript eslint directives. Reduce the ceiling whenever warnings are repaired; the target is zero.
 
 Committed Husky hooks are installed through `npm install`/`prepare`: pre-commit runs lint-staged and pre-push runs lint, type-check, all Vitest projects, and a production build. Git's `--no-verify` escape hatch must be exceptional and disclosed.
 

--- a/convex/__tests__/readings.test.ts
+++ b/convex/__tests__/readings.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { getHistoryRowCap, getHistorySampleWindows } from "../readings";
+
+describe("reading history query limits", () => {
+  it("caps long filtered ranges before legacy raw payloads exceed query limits", () => {
+    const startTime = 1_700_000_000_000;
+    const thirtyDaysLater = startTime + 30 * 24 * 60 * 60 * 1000;
+
+    expect(getHistoryRowCap(startTime, thirtyDaysLater, 1)).toBe(500);
+    expect(getHistoryRowCap(startTime, thirtyDaysLater, 5)).toBe(500);
+  });
+
+  it("keeps short raw ranges bounded to their expected reading count", () => {
+    const startTime = 1_700_000_000_000;
+    const oneHourLater = startTime + 60 * 60 * 1000;
+
+    expect(getHistoryRowCap(startTime, oneHourLater, 1)).toBe(60);
+  });
+
+  it("returns zero for empty or inverted ranges", () => {
+    expect(getHistoryRowCap(200, 200, 5)).toBe(0);
+    expect(getHistoryRowCap(300, 200, 5)).toBe(0);
+  });
+
+  it("samples long ranges uniformly from start to end", () => {
+    const startTime = 1_700_000_000_000;
+    const thirtyDaysLater = startTime + 30 * 24 * 60 * 60 * 1000;
+    const windows = getHistorySampleWindows(startTime, thirtyDaysLater, 5);
+
+    expect(windows).toHaveLength(500);
+    expect(windows?.[0].startTime).toBe(startTime);
+    expect(windows?.at(-1)?.endTime).toBe(thirtyDaysLater);
+    expect(windows?.[249].endTime).toBe(windows?.[250].startTime);
+  });
+
+  it("does not sample ranges that fit within the safe row cap", () => {
+    const startTime = 1_700_000_000_000;
+    const oneHourLater = startTime + 60 * 60 * 1000;
+
+    expect(getHistorySampleWindows(startTime, oneHourLater, 1)).toBeNull();
+  });
+
+  it("samples according to the user's configured collection interval", () => {
+    const startTime = 1_700_000_000_000;
+    const oneDayLater = startTime + 24 * 60 * 60 * 1000;
+
+    expect(getHistorySampleWindows(startTime, oneDayLater, 1)).toHaveLength(500);
+    expect(getHistorySampleWindows(startTime, oneDayLater, 5)).toBeNull();
+  });
+});

--- a/convex/readings.ts
+++ b/convex/readings.ts
@@ -3,6 +3,11 @@ import { v } from "convex/values";
 import { auth } from "./auth";
 import { Id } from "./_generated/dataModel";
 
+// deviceReadings can contain a legacy raw EcoFlow payload, so reading thousands
+// of documents in one query can exceed Convex's transaction read limits before
+// the documents are mapped to the much smaller client-facing history shape.
+const MAX_HISTORY_DOCUMENTS = 500;
+
 // ─── Queries ──────────────────────────────────────────────────────────────────
 
 /**
@@ -162,6 +167,12 @@ export const history = query({
     // are inserted in the future. This is the #1 bandwidth optimization.
     const effectiveEndTime = Math.min(args.endTime, Date.now());
 
+    // An inverted custom range produces contradictory index bounds. Treat it
+    // as an empty range instead of allowing the database query to fail.
+    if (args.startTime >= effectiveEndTime) {
+      return { readings: [], summary: null };
+    }
+
     // Get user's devices to scope the query
     const userDevices = await ctx.db
       .query("devices")
@@ -178,21 +189,26 @@ export const history = query({
       if (!owned) return { readings: [], summary: null };
     }
 
-    // Adaptive row cap: derive from the requested time span and expected
-    // collection interval (~5 min) so long ranges (7d/30d) don't silently
-    // drop older readings, while still capping bandwidth.
+    const collectionSettings = await ctx.db
+      .query("dataRetentionSettings")
+      .withIndex("by_userId", (q) => q.eq("userId", userId))
+      .first();
+    const collectionIntervalMinutes = Math.max(
+      1,
+      collectionSettings?.collectionIntervalMinutes ?? 5
+    );
+
     const agg = args.aggregation ?? "raw";
-    let rowCap: number;
-    if (agg === "raw") {
-      rowCap = 4000;
-    } else {
-      const durationMs = effectiveEndTime - args.startTime;
-      const approxIntervalMs = 5 * 60 * 1000; // 5 minutes
-      const estimatedRows =
-        durationMs > 0 ? Math.ceil(durationMs / approxIntervalMs) : 0;
-      // Clamp between 2000 (min for aggregates) and 4000 (previous global cap)
-      rowCap = Math.min(4000, Math.max(2000, estimatedRows));
-    }
+    const rowCap = getHistoryRowCap(
+      args.startTime,
+      effectiveEndTime,
+      collectionIntervalMinutes
+    );
+    const sampleWindows = getHistorySampleWindows(
+      args.startTime,
+      effectiveEndTime,
+      collectionIntervalMinutes
+    );
 
     const allReadings: Array<{
       deviceId: Id<"devices">;
@@ -220,22 +236,37 @@ export const history = query({
       const device = deviceMap.get(devId);
       if (!device) continue;
 
-      // Fetch DESC so we always keep the NEWEST readings for large ranges,
-      // then reverse to chronological order for aggregation/charts.
-      // Row cap is adaptive based on aggregation level.
-      const rawReadings = await ctx.db
-        .query("deviceReadings")
-        .withIndex("by_deviceId_recordedAt", (q) =>
-          q
-            .eq("deviceId", devId)
-            .gte("recordedAt", args.startTime)
-            .lte("recordedAt", effectiveEndTime)
-        )
-        .order("desc")
-        .take(rowCap);
-
-      // Reverse to chronological order (oldest → newest)
-      const readings = rawReadings.reverse();
+      const readings = sampleWindows
+        ? (
+            await Promise.all(
+              sampleWindows.map((window, index) =>
+                ctx.db
+                  .query("deviceReadings")
+                  .withIndex("by_deviceId_recordedAt", (q) => {
+                    const range = q
+                      .eq("deviceId", devId)
+                      .gte("recordedAt", window.startTime);
+                    return index === sampleWindows.length - 1
+                      ? range.lte("recordedAt", window.endTime)
+                      : range.lt("recordedAt", window.endTime);
+                  })
+                  .order("desc")
+                  .first()
+              )
+            )
+          ).filter((reading) => reading !== null)
+        : (
+            await ctx.db
+              .query("deviceReadings")
+              .withIndex("by_deviceId_recordedAt", (q) =>
+                q
+                  .eq("deviceId", devId)
+                  .gte("recordedAt", args.startTime)
+                  .lte("recordedAt", effectiveEndTime)
+              )
+              .order("desc")
+              .take(rowCap)
+          ).reverse();
 
       for (const r of readings) {
         allReadings.push({
@@ -460,7 +491,6 @@ export const insertReading = internalMutation({
       remainingTime: args.remainingTime,
       temperature: args.temperature,
       status: args.status,
-      rawData: args.rawData,
       recordedAt: args.recordedAt,
       // Config state
       acEnabled: args.acEnabled,
@@ -507,6 +537,42 @@ export const getLatestTimestamp = internalQuery({
 });
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
+
+export function getHistoryRowCap(
+  startTime: number,
+  endTime: number,
+  collectionIntervalMinutes: number
+): number {
+  const durationMs = endTime - startTime;
+  if (durationMs <= 0) return 0;
+
+  const expectedIntervalMs = Math.max(1, collectionIntervalMinutes) * 60 * 1000;
+  const estimatedRows = Math.ceil(durationMs / expectedIntervalMs);
+
+  return Math.min(MAX_HISTORY_DOCUMENTS, Math.max(1, estimatedRows));
+}
+
+export function getHistorySampleWindows(
+  startTime: number,
+  endTime: number,
+  collectionIntervalMinutes: number
+): Array<{ startTime: number; endTime: number }> | null {
+  const durationMs = endTime - startTime;
+  if (durationMs <= 0) return null;
+
+  const expectedIntervalMs = Math.max(1, collectionIntervalMinutes) * 60 * 1000;
+  const estimatedRows = Math.ceil(durationMs / expectedIntervalMs);
+  if (estimatedRows <= MAX_HISTORY_DOCUMENTS) return null;
+
+  const windowMs = durationMs / MAX_HISTORY_DOCUMENTS;
+  return Array.from({ length: MAX_HISTORY_DOCUMENTS }, (_, index) => ({
+    startTime: startTime + index * windowMs,
+    endTime:
+      index === MAX_HISTORY_DOCUMENTS - 1
+        ? endTime
+        : startTime + (index + 1) * windowMs,
+  }));
+}
 
 interface ReadingRow {
   batteryLevel: number | null;

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -46,6 +46,8 @@ export default defineSchema({
     remainingTime: v.optional(v.float64()),
     temperature: v.optional(v.float64()),
     status: v.optional(v.string()),
+    // Legacy imports/readings may contain the full EcoFlow quota payload.
+    // New inserts omit it because history queries only use extracted fields.
     rawData: v.optional(v.any()),
     recordedAt: v.float64(), // epoch ms
     // ─── Config state (extracted from quota) ─────────────────────────────────


### PR DESCRIPTION
## Summary

- reject empty or inverted history ranges before building indexed reads
- bound payload-heavy history queries and sample long ranges evenly across the requested interval
- use each user's configured collection interval when deciding whether sampling is needed
- stop persisting unused raw EcoFlow quota payloads for new readings
- document a safe, isolated E2E deployment configuration

## Root cause

Long analytics and history filters could load thousands of complete `deviceReadings` documents. Legacy rows may contain the full EcoFlow quota payload, causing the Convex query to exceed transaction read limits before mapping the documents to the smaller client response. Reversed custom ranges could also create contradictory index bounds.

## Impact

Analytics and history filters remain bounded while representing the complete selected interval, and invalid custom ranges return an empty result instead of a server error. New readings are smaller because the unused raw payload is no longer stored.

## Validation

- `npm run lint` — passed with the existing 48-warning ceiling
- `npm run type-check` — passed
- `npm test` — 22 tests passed
- `npm run build` — passed
- pre-push verification hook — passed